### PR TITLE
Change HTTP notification handler to use POST.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ for your Cloud Build project(s).
 There are currently 3 supported notifier types:
 
 -   [`smtp`](./smtp/README.md), which sends emails via an SMTP server.
--   [`http`](./http/README.md), which sends (HTTP `PUT`s) a JSON payload to
+-   [`http`](./http/README.md), which sends (HTTP `POST`s) a JSON payload to
     another HTTP endpoint.
 -   [`slack`](./slack/README.md), which uses a Slack webhook to post a message
     in a Slack channel.

--- a/http/README.md
+++ b/http/README.md
@@ -1,6 +1,6 @@
 # Cloud Build HTTP Notifier
 
-This notifier uses HTTP to `PUT` JSON payload notifications to the given
+This notifier uses HTTP to `POST` JSON payload notifications to the given
 recipient server.
 This notifier runs as a container via Google Cloud Run and responds to
 events that Cloud Build publishes via its
@@ -13,5 +13,5 @@ see [Configuring HTTP notifications](https://cloud.google.com/cloud-build/docs/c
 
 This notifier expects the following fields in the `delivery` map to be set:
 
-- `url`: The HTTP endpoint to which `PUT` requests will be sent. No sort of
+- `url`: The HTTP endpoint to which `POST` requests will be sent. No sort of
 authentication is expected or used.

--- a/http/main.go
+++ b/http/main.go
@@ -64,12 +64,13 @@ func (h *httpNotifier) SendNotification(ctx context.Context, event *notifiers.Cl
 		return fmt.Errorf("failed to marshal event to JSON: %v", je)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPut, h.url, bytes.NewBuffer(je))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, h.url, bytes.NewBuffer(je))
 	if err != nil {
 		return fmt.Errorf("failed to create a new HTTP request: %v", err)
 	}
 
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "GCB-Notifier/0.1 (http)")
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {


### PR DESCRIPTION
Also set User-Agent header so users can identify requests.

POST seems more fitting since we're not explicitly upserting resources
here, and this matches the incoming method type from Cloud Pubsub.

In particular from the RFC, this falls under "data-accepting process, a
gateway to some other protocol, or a separate entity that accepts
annotations", which makes POST a better fit. See
https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.5 for more
details.

/cc @navierula for any other doc changes.