### PR TITLE
Remove deploy step from cb.yamls.

### DIFF
--- a/http/cloudbuild.yaml
+++ b/http/cloudbuild.yaml
@@ -26,11 +26,6 @@ steps:
   args:
     - --smoketest
     - --alsologtostderr
-# Push the new Docker image to GCR so Cloud Run pulls the _actual_ latest.
-- name: gcr.io/cloud-builders/docker
-  args:
-    - push
-    - $_IMAGE_PATH
 
 # Push the image.
 images:

--- a/slack/cloudbuild.yaml
+++ b/slack/cloudbuild.yaml
@@ -26,11 +26,6 @@ steps:
   args:
     - --smoketest
     - --alsologtostderr
-# Push the new Docker image to GCR so Cloud Run pulls the _actual_ latest.
-- name: gcr.io/cloud-builders/docker
-  args:
-    - push
-    - $_IMAGE_PATH
 
 # Push the image.
 images:

--- a/smtp/cloudbuild.yaml
+++ b/smtp/cloudbuild.yaml
@@ -26,11 +26,6 @@ steps:
   args:
     - --smoketest
     - --alsologtostderr
-# Push the new Docker image to GCR so Cloud Run pulls the _actual_ latest.
-- name: gcr.io/cloud-builders/docker
-  args:
-    - push
-    - $_IMAGE_PATH
 
 # Push the image.
 images:


### PR DESCRIPTION
By removing the `gcloud run deploy` step from our notifiers' cb.yamls, we remove several headaches:

- Having a lot of variables in the YAML 😵 
- Burying image startup issues (usually notifier config-related) in the deploy step as part of the `gcloud builds submit` command (i.e. "my image built properly but the overall build failed" confusion).
- Cloud Build/Cloud Run IAM permission-granting issues.
- Dealing with [domain/org-scoped project IDs](https://cloud.google.com/container-registry/docs/overview#domain-scoped_projects). By allowing users to put whatever (hopefully) valid container registry path in the `_IMAGE_PATH` subst. and no longer using `$PROJECT_ID` in the YAML, we allow for an escape hatch should the project ID have a colon (or other "weird" character) in it.

I also removed a lot of the gratuitous quoting (a string `foo` as `'foo'`) from the YAML.

I tested the change by running the following command (similar for all notifiers):

```bash
gcloud builds submit . \
--config=./http/cloudbuild.yaml \
--substitutions=_IMAGE_PATH=gcr.io/<some-project-id>/notifiers/http
```

The deploy step can now be run separately, basically the same as it was before the change, modulo changes with `_IMAGE_PATH` etc.