### PR TITLE
Switch notifier binaries to push subscriptions.

### DIFF
--- a/http/Dockerfile
+++ b/http/Dockerfile
@@ -18,6 +18,16 @@ WORKDIR /go-src/http
 RUN go test /go-src/http
 RUN go build -o /go-app .
 
+# From the Cloud Run docs:
+# https://cloud.google.com/run/docs/tutorials/pubsub#looking_at_the_code
+# Use the official Debian slim image for a lean production container.
+# https://hub.docker.com/_/debian
+# https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
+FROM debian:buster-slim
+RUN set -x && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
 FROM gcr.io/distroless/base
 COPY --from=build-env /go-app /
 ENTRYPOINT ["/go-app", "--alsologtostderr", "--v=0"]

--- a/lib/notifiers/go.mod
+++ b/lib/notifiers/go.mod
@@ -4,18 +4,16 @@ go 1.14
 
 require (
 	cloud.google.com/go v0.52.0
-	cloud.google.com/go/pubsub v1.2.0
+	cloud.google.com/go/pubsub v1.2.0 // indirect
 	cloud.google.com/go/storage v1.5.0
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/protobuf v1.4.0
 	github.com/google/cel-go v0.4.1
 	github.com/google/go-cmp v0.4.0
 	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e // indirect
-	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 	golang.org/x/sys v0.0.0-20200413165638-669c56c373c4 // indirect
-	google.golang.org/api v0.15.0
 	google.golang.org/genproto v0.0.0-20200413115906-b5235f65be36
-	google.golang.org/grpc v1.28.1
+	google.golang.org/grpc v1.28.1 // indirect
 	google.golang.org/protobuf v1.21.0
 	gopkg.in/yaml.v2 v2.2.8
 )

--- a/slack/Dockerfile
+++ b/slack/Dockerfile
@@ -18,6 +18,16 @@ WORKDIR /go-src/slack
 RUN go test /go-src/slack
 RUN go build -o /go-app .
 
+# From the Cloud Run docs:
+# https://cloud.google.com/run/docs/tutorials/pubsub#looking_at_the_code
+# Use the official Debian slim image for a lean production container.
+# https://hub.docker.com/_/debian
+# https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
+FROM debian:buster-slim
+RUN set -x && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
 FROM gcr.io/distroless/base
 COPY --from=build-env /go-app /
 ENTRYPOINT ["/go-app", "--alsologtostderr", "--v=0"]

--- a/smtp/Dockerfile
+++ b/smtp/Dockerfile
@@ -18,6 +18,16 @@ WORKDIR /go-src/smtp
 RUN go test /go-src/smtp
 RUN go build -o /go-app .
 
+# From the Cloud Run docs:
+# https://cloud.google.com/run/docs/tutorials/pubsub#looking_at_the_code
+# Use the official Debian slim image for a lean production container.
+# https://hub.docker.com/_/debian
+# https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
+FROM debian:buster-slim
+RUN set -x && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
 FROM gcr.io/distroless/base
 COPY --from=build-env /go-app /
 ENTRYPOINT ["/go-app", "--alsologtostderr", "--v=0"]


### PR DESCRIPTION
Due to how Cloud Run (managed) expects your image to behave
(https://cloud.google.com/run/docs/tips#avoiding_background_activities),
our previous usage of Cloud Pub/Sub pull subscribers was incorrect and
resulted in Cloud Run scaling our notifiers to zero! Big oof.

I followed along with the docs at:
https://cloud.google.com/run/docs/tutorials/pubsub#cloud-run

Thankfully, this was mostly a change in the base notifier library. The
Dockerfile changes that I had to make come from that Cloud Run doc and
(AFAICT) help with the Pub/Sub SA-Cloud Run interaction by getting a
recent version of ca-certificates and using it in the image.