### PR TITLE
Add trigger cb.yamls for tests and deploys.

### DIFF
--- a/http/buildtest.cloudbuild.yaml
+++ b/http/buildtest.cloudbuild.yaml
@@ -14,7 +14,6 @@
 
 steps:
 - name: gcr.io/cloud-builders/docker
-  id: build-http-notifier
   args:
   - build
   - --file=./http/Dockerfile

--- a/http/buildtest.cloudbuild.yaml
+++ b/http/buildtest.cloudbuild.yaml
@@ -1,0 +1,24 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+- name: gcr.io/cloud-builders/docker
+  id: build-http-notifier
+  args:
+  - build
+  - --file=./http/Dockerfile
+  - '.'
+
+tags:
+- cloud-build-notifiers-http

--- a/http/deploy.cloudbuild.yaml
+++ b/http/deploy.cloudbuild.yaml
@@ -15,24 +15,28 @@
 steps:
 # Build the binary and put it into the builder image.
 - name: gcr.io/cloud-builders/docker
-  id: build-http-notifier
   args:
   - build
   - -t
-  - gcr.io/gcb-release/notifiers/http:$TAG_NAME
+  - gcr.io/$_REGISTRY_PROJECT/notifiers/http:$TAG_NAME
+  - -t
+  - gcr.io/$_REGISTRY_PROJECT/notifiers/http:latest
   - --file=./http/Dockerfile
   - '.'
 # Run the smoketest to verify that everything built correctly.
-- name: gcr.io/gcb-release/notifiers/http:$TAG_NAME
-  id: smoketest-http-notifier
+- name: gcr.io/$_REGISTRY_PROJECT/notifiers/http:$TAG_NAME
   args:
   - --smoketest
   - --alsologtostderr
 
 # Push the image.
 images:
-- gcr.io/gcb-release/notifiers/http:$TAG_NAME
+- gcr.io/$_REGISTRY_PROJECT/notifiers/http:$TAG_NAME
+- gcr.io/$_REGISTRY_PROJECT/notifiers/http:latest
+
+substitutions:
+  _REGISTRY_PROJECT: gcb-release
 
 tags:
 - cloud-build-notifiers-http
-- http:$TAG_NAME
+- http-$TAG_NAME

--- a/http/deploy.cloudbuild.yaml
+++ b/http/deploy.cloudbuild.yaml
@@ -1,0 +1,38 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+# Build the binary and put it into the builder image.
+- name: gcr.io/cloud-builders/docker
+  id: build-http-notifier
+  args:
+  - build
+  - -t
+  - gcr.io/gcb-release/notifiers/http:$TAG_NAME
+  - --file=./http/Dockerfile
+  - '.'
+# Run the smoketest to verify that everything built correctly.
+- name: gcr.io/gcb-release/notifiers/http:$TAG_NAME
+  id: smoketest-http-notifier
+  args:
+  - --smoketest
+  - --alsologtostderr
+
+# Push the image.
+images:
+- gcr.io/gcb-release/notifiers/http:$TAG_NAME
+
+tags:
+- cloud-build-notifiers-http
+- http:$TAG_NAME

--- a/slack/buildtest.cloudbuild.yaml
+++ b/slack/buildtest.cloudbuild.yaml
@@ -1,0 +1,24 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+- name: gcr.io/cloud-builders/docker
+  id: build-slack-notifier
+  args:
+  - build
+  - --file=./slack/Dockerfile
+  - '.'
+
+tags:
+- cloud-build-notifiers-slack

--- a/slack/buildtest.cloudbuild.yaml
+++ b/slack/buildtest.cloudbuild.yaml
@@ -14,7 +14,6 @@
 
 steps:
 - name: gcr.io/cloud-builders/docker
-  id: build-slack-notifier
   args:
   - build
   - --file=./slack/Dockerfile

--- a/slack/deploy.cloudbuild.yaml
+++ b/slack/deploy.cloudbuild.yaml
@@ -15,24 +15,28 @@
 steps:
 # Build the binary and put it into the builder image.
 - name: gcr.io/cloud-builders/docker
-  id: build-slack-notifier
   args:
   - build
   - -t
-  - gcr.io/gcb-release/notifiers/slack:$TAG_NAME
+  - gcr.io/$_REGISTRY_PROJECT/notifiers/slack:$TAG_NAME
+  - -t
+  - gcr.io/$_REGISTRY_PROJECT/notifiers/slack:latest
   - --file=./slack/Dockerfile
   - '.'
 # Run the smoketest to verify that everything built correctly.
-- name: gcr.io/gcb-release/notifiers/slack:$TAG_NAME
-  id: smoketest-slack-notifier
+- name: gcr.io/$_REGISTRY_PROJECT/notifiers/slack:$TAG_NAME
   args:
   - --smoketest
   - --alsologtostderr
 
 # Push the image.
 images:
-- gcr.io/gcb-release/notifiers/slack:$TAG_NAME
+- gcr.io/$_REGISTRY_PROJECT/notifiers/slack:$TAG_NAME
+- gcr.io/$_REGISTRY_PROJECT/notifiers/slack:latest
+
+substitutions:
+  _REGISTRY_PROJECT: gcb-release
 
 tags:
 - cloud-build-notifiers-slack
-- slack:$TAG_NAME
+- slack-$TAG_NAME

--- a/slack/deploy.cloudbuild.yaml
+++ b/slack/deploy.cloudbuild.yaml
@@ -1,0 +1,38 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+# Build the binary and put it into the builder image.
+- name: gcr.io/cloud-builders/docker
+  id: build-slack-notifier
+  args:
+  - build
+  - -t
+  - gcr.io/gcb-release/notifiers/slack:$TAG_NAME
+  - --file=./slack/Dockerfile
+  - '.'
+# Run the smoketest to verify that everything built correctly.
+- name: gcr.io/gcb-release/notifiers/slack:$TAG_NAME
+  id: smoketest-slack-notifier
+  args:
+  - --smoketest
+  - --alsologtostderr
+
+# Push the image.
+images:
+- gcr.io/gcb-release/notifiers/slack:$TAG_NAME
+
+tags:
+- cloud-build-notifiers-slack
+- slack:$TAG_NAME

--- a/smtp/buildtest.cloudbuild.yaml
+++ b/smtp/buildtest.cloudbuild.yaml
@@ -1,0 +1,24 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+- name: gcr.io/cloud-builders/docker
+  id: build-smtp-notifier
+  args:
+  - build
+  - --file=./smtp/Dockerfile
+  - '.'
+
+tags:
+- cloud-build-notifiers-smtp

--- a/smtp/buildtest.cloudbuild.yaml
+++ b/smtp/buildtest.cloudbuild.yaml
@@ -14,7 +14,6 @@
 
 steps:
 - name: gcr.io/cloud-builders/docker
-  id: build-smtp-notifier
   args:
   - build
   - --file=./smtp/Dockerfile

--- a/smtp/deploy.cloudbuild.yaml
+++ b/smtp/deploy.cloudbuild.yaml
@@ -15,24 +15,28 @@
 steps:
 # Build the binary and put it into the builder image.
 - name: gcr.io/cloud-builders/docker
-  id: build-smtp-notifier
   args:
   - build
   - -t
-  - gcr.io/gcb-release/notifiers/smtp:$TAG_NAME
+  - gcr.io/$_REGISTRY_PROJECT/notifiers/smtp:$TAG_NAME
+  - -t
+  - gcr.io/$_REGISTRY_PROJECT/notifiers/smtp:latest
   - --file=./smtp/Dockerfile
   - '.'
 # Run the smoketest to verify that everything built correctly.
-- name: gcr.io/gcb-release/notifiers/smtp:$TAG_NAME
-  id: smoketest-smtp-notifier
+- name: gcr.io/$_REGISTRY_PROJECT/notifiers/smtp:$TAG_NAME
   args:
   - --smoketest
   - --alsologtostderr
 
 # Push the image.
 images:
-- gcr.io/gcb-release/notifiers/smtp:$TAG_NAME
+- gcr.io/$_REGISTRY_PROJECT/notifiers/smtp:$TAG_NAME
+- gcr.io/$_REGISTRY_PROJECT/notifiers/smtp:latest
+
+substitutions:
+  _REGISTRY_PROJECT: gcb-release
 
 tags:
 - cloud-build-notifiers-smtp
-- smtp:$TAG_NAME
+- smtp-$TAG_NAME

--- a/smtp/deploy.cloudbuild.yaml
+++ b/smtp/deploy.cloudbuild.yaml
@@ -1,0 +1,38 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+# Build the binary and put it into the builder image.
+- name: gcr.io/cloud-builders/docker
+  id: build-smtp-notifier
+  args:
+  - build
+  - -t
+  - gcr.io/gcb-release/notifiers/smtp:$TAG_NAME
+  - --file=./smtp/Dockerfile
+  - '.'
+# Run the smoketest to verify that everything built correctly.
+- name: gcr.io/gcb-release/notifiers/smtp:$TAG_NAME
+  id: smoketest-smtp-notifier
+  args:
+  - --smoketest
+  - --alsologtostderr
+
+# Push the image.
+images:
+- gcr.io/gcb-release/notifiers/smtp:$TAG_NAME
+
+tags:
+- cloud-build-notifiers-smtp
+- smtp:$TAG_NAME


### PR DESCRIPTION
These cb.yamls will allow us to create triggers for specific build+test and separate deploy functionality. This also allows us to take advantage of semver git tagging for version tagging our notifier images.

I decided to keep the older `cloudbuild.yamls` since we still have code/docs that reference them. With these new cb.yamls, they will eventually become obsolete and we will no longer require users to build their own notifiers.