### PR TITLE
Update deploy yamls for integration with cloud-build-notifiers AR.

### DIFF
--- a/http/deploy.cloudbuild.yaml
+++ b/http/deploy.cloudbuild.yaml
@@ -17,24 +17,24 @@ steps:
 - name: gcr.io/cloud-builders/docker
   args:
   - build
-  - --tag=$_REGISTRY/http:$TAG_NAME
-  - --tag=$_REGISTRY/http:latest
+  - --tag=${_REGISTRY}/http:${TAG_NAME}
+  - --tag=${_REGISTRY}/http:latest
   - --file=./http/Dockerfile
   - '.'
 # Run the smoketest to verify that everything built correctly.
-- name: $_REGISTRY/http:$TAG_NAME
+- name: ${_REGISTRY}/http:${TAG_NAME}
   args:
   - --smoketest
   - --alsologtostderr
 
 # Push the image with tags.
 images:
-- $_REGISTRY/http:$TAG_NAME
-- $_REGISTRY/http:latest
+- ${_REGISTRY}/http:${TAG_NAME}
+- ${_REGISTRY}/http:latest
 
 substitutions:
   _REGISTRY: us-east1-docker.pkg.dev/gcb-release/cloud-build-notifiers
 
 tags:
 - cloud-build-notifiers-http
-- http-$TAG_NAME
+- http-${TAG_NAME}

--- a/http/deploy.cloudbuild.yaml
+++ b/http/deploy.cloudbuild.yaml
@@ -17,25 +17,23 @@ steps:
 - name: gcr.io/cloud-builders/docker
   args:
   - build
-  - -t
-  - gcr.io/$_REGISTRY_PROJECT/notifiers/http:$TAG_NAME
-  - -t
-  - gcr.io/$_REGISTRY_PROJECT/notifiers/http:latest
+  - --tag=$_REGISTRY/http:$TAG_NAME
+  - --tag=$_REGISTRY/http:latest
   - --file=./http/Dockerfile
   - '.'
 # Run the smoketest to verify that everything built correctly.
-- name: gcr.io/$_REGISTRY_PROJECT/notifiers/http:$TAG_NAME
+- name: $_REGISTRY/http:$TAG_NAME
   args:
   - --smoketest
   - --alsologtostderr
 
-# Push the image.
+# Push the image with tags.
 images:
-- gcr.io/$_REGISTRY_PROJECT/notifiers/http:$TAG_NAME
-- gcr.io/$_REGISTRY_PROJECT/notifiers/http:latest
+- $_REGISTRY/http:$TAG_NAME
+- $_REGISTRY/http:latest
 
 substitutions:
-  _REGISTRY_PROJECT: gcb-release
+  _REGISTRY: us-east1-docker.pkg.dev/gcb-release/cloud-build-notifiers
 
 tags:
 - cloud-build-notifiers-http

--- a/slack/deploy.cloudbuild.yaml
+++ b/slack/deploy.cloudbuild.yaml
@@ -17,25 +17,23 @@ steps:
 - name: gcr.io/cloud-builders/docker
   args:
   - build
-  - -t
-  - gcr.io/$_REGISTRY_PROJECT/notifiers/slack:$TAG_NAME
-  - -t
-  - gcr.io/$_REGISTRY_PROJECT/notifiers/slack:latest
+  - --tag=$_REGISTRY/slack:$TAG_NAME
+  - --tag=$_REGISTRY/slack:latest
   - --file=./slack/Dockerfile
   - '.'
 # Run the smoketest to verify that everything built correctly.
-- name: gcr.io/$_REGISTRY_PROJECT/notifiers/slack:$TAG_NAME
+- name: $_REGISTRY/slack:$TAG_NAME
   args:
   - --smoketest
   - --alsologtostderr
 
-# Push the image.
+# Push the image with tags.
 images:
-- gcr.io/$_REGISTRY_PROJECT/notifiers/slack:$TAG_NAME
-- gcr.io/$_REGISTRY_PROJECT/notifiers/slack:latest
+- $_REGISTRY/slack:$TAG_NAME
+- $_REGISTRY/slack:latest
 
 substitutions:
-  _REGISTRY_PROJECT: gcb-release
+  _REGISTRY: us-east1-docker.pkg.dev/gcb-release/cloud-build-notifiers
 
 tags:
 - cloud-build-notifiers-slack

--- a/slack/deploy.cloudbuild.yaml
+++ b/slack/deploy.cloudbuild.yaml
@@ -17,24 +17,24 @@ steps:
 - name: gcr.io/cloud-builders/docker
   args:
   - build
-  - --tag=$_REGISTRY/slack:$TAG_NAME
-  - --tag=$_REGISTRY/slack:latest
+  - --tag=${_REGISTRY}/slack:${TAG_NAME}
+  - --tag=${_REGISTRY}/slack:latest
   - --file=./slack/Dockerfile
   - '.'
 # Run the smoketest to verify that everything built correctly.
-- name: $_REGISTRY/slack:$TAG_NAME
+- name: ${_REGISTRY}/slack:${TAG_NAME}
   args:
   - --smoketest
   - --alsologtostderr
 
 # Push the image with tags.
 images:
-- $_REGISTRY/slack:$TAG_NAME
-- $_REGISTRY/slack:latest
+- ${_REGISTRY}/slack:${TAG_NAME}
+- ${_REGISTRY}/slack:latest
 
 substitutions:
   _REGISTRY: us-east1-docker.pkg.dev/gcb-release/cloud-build-notifiers
 
 tags:
 - cloud-build-notifiers-slack
-- slack-$TAG_NAME
+- slack-${TAG_NAME}

--- a/smtp/deploy.cloudbuild.yaml
+++ b/smtp/deploy.cloudbuild.yaml
@@ -17,25 +17,23 @@ steps:
 - name: gcr.io/cloud-builders/docker
   args:
   - build
-  - -t
-  - gcr.io/$_REGISTRY_PROJECT/notifiers/smtp:$TAG_NAME
-  - -t
-  - gcr.io/$_REGISTRY_PROJECT/notifiers/smtp:latest
+  - --tag=$_REGISTRY/smtp:$TAG_NAME
+  - --tag=$_REGISTRY/smtp:latest
   - --file=./smtp/Dockerfile
   - '.'
 # Run the smoketest to verify that everything built correctly.
-- name: gcr.io/$_REGISTRY_PROJECT/notifiers/smtp:$TAG_NAME
+- name: $_REGISTRY/smtp:$TAG_NAME
   args:
   - --smoketest
   - --alsologtostderr
 
-# Push the image.
+# Push the image with tags.
 images:
-- gcr.io/$_REGISTRY_PROJECT/notifiers/smtp:$TAG_NAME
-- gcr.io/$_REGISTRY_PROJECT/notifiers/smtp:latest
+- $_REGISTRY/smtp:$TAG_NAME
+- $_REGISTRY/smtp:latest
 
 substitutions:
-  _REGISTRY_PROJECT: gcb-release
+  _REGISTRY: us-east1-docker.pkg.dev/gcb-release/cloud-build-notifiers
 
 tags:
 - cloud-build-notifiers-smtp

--- a/smtp/deploy.cloudbuild.yaml
+++ b/smtp/deploy.cloudbuild.yaml
@@ -17,24 +17,24 @@ steps:
 - name: gcr.io/cloud-builders/docker
   args:
   - build
-  - --tag=$_REGISTRY/smtp:$TAG_NAME
-  - --tag=$_REGISTRY/smtp:latest
+  - --tag=${_REGISTRY}/smtp:${TAG_NAME}
+  - --tag=${_REGISTRY}/smtp:latest
   - --file=./smtp/Dockerfile
   - '.'
 # Run the smoketest to verify that everything built correctly.
-- name: $_REGISTRY/smtp:$TAG_NAME
+- name: ${_REGISTRY}/smtp:${TAG_NAME}
   args:
   - --smoketest
   - --alsologtostderr
 
 # Push the image with tags.
 images:
-- $_REGISTRY/smtp:$TAG_NAME
-- $_REGISTRY/smtp:latest
+- ${_REGISTRY}/smtp:${TAG_NAME}
+- ${_REGISTRY}/smtp:latest
 
 substitutions:
   _REGISTRY: us-east1-docker.pkg.dev/gcb-release/cloud-build-notifiers
 
 tags:
 - cloud-build-notifiers-smtp
-- smtp-$TAG_NAME
+- smtp-${TAG_NAME}


### PR DESCRIPTION
These deploy yamls now upload images to the `us-east1-docker.pkg.dev/gcb-release/cloud-build-notifiers` in `gcb-release`. The image tagging remains the same.

After these are submitted, I will setup triggers in the `cloud-build-notifiers` GCP project to run tags.