### PR TITLE
Update config API Version to be c-b-n/v1.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,6 @@
 This repo provides deployable notifier images and sources, as well as libraries
 for creating new notifiers.
 
-> This is an Alpha release of Cloud Build Notifiers.
-> This codebase might be changed in ways that are not backwards-compatible.
-> We do not recommend using this codebase for production applications.
-> Furthermore, this release is not subject to any SLA or deprecation policy.
-
 [Cloud Build](https://cloud.google.com/cloud-build) notifiers are Docker
 containers that connect to the
 [Cloud Build Pub/Sub topic](https://cloud.google.com/cloud-build/docs/send-build-notifications)
@@ -30,11 +25,11 @@ There are currently 3 supported notifier types:
 -   [`slack`](./slack/README.md), which uses a Slack webhook to post a message
     in a Slack channel.
 
-**See the [Google Cloud Alpha docs](https://cloud.google.com/cloud-build/docs/configure-notifications) for how to use Cloud Build Notifiers.**
+**See the [Google Cloud docs](https://cloud.google.com/cloud-build/docs/configure-notifications) for how to use Cloud Build Notifiers.**
 
-**Note: Docs are only available to Cloud Build Alpha users.**
+## Setup Script
 
-A setup script exists that should automate _most_ of the notifier setup.
+A [setup script](./setup.sh) exists that should automate _most_ of the notifier setup.
 
 Run `./setup.sh --help` for usage instructions.
 

--- a/bigquery/README.md
+++ b/bigquery/README.md
@@ -1,9 +1,6 @@
 # Cloud Build BigQuery Notifier
 
-This notifier pushes build data to a BigQuery instance. *Under Development*
+This notifier pushes build data to a BigQuery instance.
 
-> This is an Alpha release of Cloud Build Notifiers.
-> This codebase might be changed in ways that are not backwards-compatible.
-> We do not recommend using this codebase for production applications.
-> Furthermore, this release is not subject to any SLA or deprecation policy.
+*Alpha Feature - Under Development*
 

--- a/bigquery/bigquery.yaml
+++ b/bigquery/bigquery.yaml
@@ -1,4 +1,4 @@
-apiVersion: cloud-build-notifiers/v1alpha1
+apiVersion: cloud-build-notifiers/v1
 kind: BigQueryNotifier
 metadata:
   name: example-bigquery-notifier

--- a/http/README.md
+++ b/http/README.md
@@ -3,11 +3,6 @@
 This notifier uses HTTP to `POST` JSON payload notifications to the given
 recipient server.
 
-> This is an Alpha release of Cloud Build Notifiers.
-> This codebase might be changed in ways that are not backwards-compatible.
-> We do not recommend using this codebase for production applications.
-> Furthermore, this release is not subject to any SLA or deprecation policy.
-
 This notifier runs as a container via Google Cloud Run and responds to
 events that Cloud Build publishes via its
 [Pub/Sub topic](https://cloud.google.com/cloud-build/docs/send-build-notifications).

--- a/http/http.yaml.example
+++ b/http/http.yaml.example
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: github.com/GoogleCloudPlatform/cloud-build-notifiers/v1
+apiVersion: cloud-build-notifiers/v1
 kind: HTTPNotifier
 metadata:
   name: example-http-notifier

--- a/http/http.yaml.example
+++ b/http/http.yaml.example
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: cloud-build-notifiers/v1alpha1
+apiVersion: github.com/GoogleCloudPlatform/cloud-build-notifiers/v1
 kind: HTTPNotifier
 metadata:
   name: example-http-notifier

--- a/lib/notifiers/README.md
+++ b/lib/notifiers/README.md
@@ -3,11 +3,6 @@
 This `notifiers` Go package exposes a lightweight, zero-magic, _optional_
 framework for writing new notifiers and extensions.
 
-> This is an Alpha release of Cloud Build Notifiers.
-> This codebase might be changed in ways that are not backwards-compatible.
-> We do not recommend using this codebase for production applications.
-> Furthermore, this release is not subject to any SLA or deprecation policy.
-
 To write your own notifier using this package, all you need to do is write
 something that implements the `notifiers.Notifier` interface and then pass that
 to `notifiers.Main` in your Go executable's `main` method (or wherever). That

--- a/lib/notifiers/notifiers.go
+++ b/lib/notifiers/notifiers.go
@@ -49,7 +49,9 @@ const (
 
 var (
 	// Set of allowed notifier Config `apiVersions`.
-	allowedYAMLAPIVersions = map[string]bool{"cloud-build-notifiers/v1alpha1": true}
+	allowedYAMLAPIVersions = map[string]bool{
+		"github.com/GoogleCloudPlatform/cloud-build-notifiers/v1": true,
+	}
 )
 
 // Flags.
@@ -170,6 +172,10 @@ func Main(notifier Notifier) error {
 			log.Warningf("failed to re-encode config YAML: %v", err)
 		} else {
 			log.V(2).Infof("got re-encoded YAML from stdin:\n%s", string(out))
+		}
+
+		if err := validateConfig(cfg); err != nil {
+			return fmt.Errorf("failed to validate config during setup check: %v", err)
 		}
 
 		if err := notifier.SetUp(ctx, cfg, new(setupCheckSecretGetter)); err != nil {

--- a/lib/notifiers/notifiers.go
+++ b/lib/notifiers/notifiers.go
@@ -50,7 +50,7 @@ const (
 var (
 	// Set of allowed notifier Config `apiVersions`.
 	allowedYAMLAPIVersions = map[string]bool{
-		"github.com/GoogleCloudPlatform/cloud-build-notifiers/v1": true,
+		"cloud-build-notifiers/v1": true,
 	}
 )
 

--- a/lib/notifiers/notifiers_test.go
+++ b/lib/notifiers/notifiers_test.go
@@ -161,7 +161,7 @@ func (f *fakeGCSReaderFactory) NewReader(_ context.Context, bucket, object strin
 }
 
 const validConfigYAML = `
-apiVersion: github.com/GoogleCloudPlatform/cloud-build-notifiers/v1
+apiVersion: cloud-build-notifiers/v1
 kind: TestNotifier
 metadata:
   name: my-test-notifier
@@ -179,7 +179,7 @@ spec:
 `
 
 var validConfig = &Config{
-	APIVersion: "github.com/GoogleCloudPlatform/cloud-build-notifiers/v1",
+	APIVersion: "cloud-build-notifiers/v1",
 	Kind:       "TestNotifier",
 	Metadata: &Metadata{
 		Name: "my-test-notifier",

--- a/lib/notifiers/notifiers_test.go
+++ b/lib/notifiers/notifiers_test.go
@@ -161,7 +161,7 @@ func (f *fakeGCSReaderFactory) NewReader(_ context.Context, bucket, object strin
 }
 
 const validConfigYAML = `
-apiVersion: cloud-build-notifiers/v1alpha1
+apiVersion: github.com/GoogleCloudPlatform/cloud-build-notifiers/v1
 kind: TestNotifier
 metadata:
   name: my-test-notifier
@@ -179,7 +179,7 @@ spec:
 `
 
 var validConfig = &Config{
-	APIVersion: "cloud-build-notifiers/v1alpha1",
+	APIVersion: "github.com/GoogleCloudPlatform/cloud-build-notifiers/v1",
 	Kind:       "TestNotifier",
 	Metadata: &Metadata{
 		Name: "my-test-notifier",

--- a/slack/README.md
+++ b/slack/README.md
@@ -3,11 +3,6 @@
 This notifier uses [Slack Webhooks](https://api.slack.com/messaging/webhooks) to
 send notifications to your Slack workspace.
 
-> This is an Alpha release of Cloud Build Notifiers.
-> This codebase might be changed in ways that are not backwards-compatible.
-> We do not recommend using this codebase for production applications.
-> Furthermore, this release is not subject to any SLA or deprecation policy.
-
 This notifier runs as a container via Google Cloud Run and responds to
 events that Cloud Build publishes via its
 [Pub/Sub topic](https://cloud.google.com/cloud-build/docs/send-build-notifications).

--- a/slack/slack.yaml.example
+++ b/slack/slack.yaml.example
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: github.com/GoogleCloudPlatform/cloud-build-notifiers/v1
+apiVersion: cloud-build-notifiers/v1
 kind: SlackNotifier
 metadata:
   name: example-slack-notifier

--- a/slack/slack.yaml.example
+++ b/slack/slack.yaml.example
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: cloud-build-notifiers/v1alpha1
+apiVersion: github.com/GoogleCloudPlatform/cloud-build-notifiers/v1
 kind: SlackNotifier
 metadata:
   name: example-slack-notifier

--- a/smtp/README.md
+++ b/smtp/README.md
@@ -2,11 +2,6 @@
 
 This notifier uses SMTP to send email notifications.
 
-> This is an Alpha release of Cloud Build Notifiers.
-> This codebase might be changed in ways that are not backwards-compatible.
-> We do not recommend using this codebase for production applications.
-> Furthermore, this release is not subject to any SLA or deprecation policy.
-
 This notifier runs as a container via Google Cloud Run and responds to
 events that Cloud Build publishes via its
 [Pub/Sub topic](https://cloud.google.com/cloud-build/docs/send-build-notifications).

--- a/smtp/main_test.go
+++ b/smtp/main_test.go
@@ -104,7 +104,7 @@ func TestGetMailConfig(t *testing.T) {
 
 func TestCorrectYAMLParseToMailConfig(t *testing.T) {
 	const yamlConfig = `
-apiVersion: gcb-notifiers/v1alpha1
+apiVersion: github.com/GoogleCloudPlatform/cloud-build-notifiers/v1
 kind: SMTPNotifier
 metadata:
   name: failed-build-email-notification

--- a/smtp/main_test.go
+++ b/smtp/main_test.go
@@ -104,7 +104,7 @@ func TestGetMailConfig(t *testing.T) {
 
 func TestCorrectYAMLParseToMailConfig(t *testing.T) {
 	const yamlConfig = `
-apiVersion: github.com/GoogleCloudPlatform/cloud-build-notifiers/v1
+apiVersion: cloud-build-notifiers/v1
 kind: SMTPNotifier
 metadata:
   name: failed-build-email-notification

--- a/smtp/smtp.yaml.example
+++ b/smtp/smtp.yaml.example
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: github.com/GoogleCloudPlatform/cloud-build-notifiers/v1
+apiVersion: cloud-build-notifiers/v1
 kind: SMTPNotifier
 metadata:
   name: example-smtp-notifier

--- a/smtp/smtp.yaml.example
+++ b/smtp/smtp.yaml.example
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: cloud-build-notifiers/v1alpha1
+apiVersion: github.com/GoogleCloudPlatform/cloud-build-notifiers/v1
 kind: SMTPNotifier
 metadata:
   name: example-smtp-notifier


### PR DESCRIPTION
- validateConfig is now called in setup_check.
- Updated tests and example files to use v1 instead of v1a1.

This is something that we want to do for our GA launch.