### PR TITLE
Use error wrapping for returned errors.

### DIFF
--- a/bigquery/main.go
+++ b/bigquery/main.go
@@ -54,7 +54,7 @@ func (bq *bqNotifier) SetUp(ctx context.Context, cfg *notifiers.Config, _ notifi
 
 	prd, err := notifiers.MakeCELPredicate(cfg.Spec.Notification.Filter)
 	if err != nil {
-		return fmt.Errorf("failed to make a CEL predicate: %v", err)
+		return fmt.Errorf("failed to make a CEL predicate: %w", err)
 	}
 	_, ok := cfg.Spec.Notification.Delivery["table"].(string)
 	if !ok {
@@ -64,7 +64,7 @@ func (bq *bqNotifier) SetUp(ctx context.Context, cfg *notifiers.Config, _ notifi
 	bq.filter = prd
 	bq.client, err = bigquery.NewClient(ctx, projectID)
 	if err != nil {
-		return fmt.Errorf("Failed to initialize bigquery client: %v", err)
+		return fmt.Errorf("Failed to initialize bigquery client: %w", err)
 	}
 
 	return nil

--- a/http/main.go
+++ b/http/main.go
@@ -41,7 +41,7 @@ type httpNotifier struct {
 func (h *httpNotifier) SetUp(_ context.Context, cfg *notifiers.Config, _ notifiers.SecretGetter) error {
 	prd, err := notifiers.MakeCELPredicate(cfg.Spec.Notification.Filter)
 	if err != nil {
-		return fmt.Errorf("failed to create CELPredicate: %v", err)
+		return fmt.Errorf("failed to create CELPredicate: %w", err)
 	}
 	h.filter = prd
 
@@ -64,19 +64,19 @@ func (h *httpNotifier) SendNotification(ctx context.Context, build *cbpb.Build) 
 
 	logURL, err := notifiers.AddUTMParams(build.LogUrl, notifiers.HTTPMedium)
 	if err != nil {
-		return fmt.Errorf("failed to add UTM params: %v", err)
+		return fmt.Errorf("failed to add UTM params: %w", err)
 	}
 	build.LogUrl = logURL
 
 	mo := protojson.MarshalOptions{}
 	jb, err := mo.Marshal(proto.MessageV2(build))
 	if err != nil {
-		return fmt.Errorf("failed to marshal Build proto to JSON: %v", err)
+		return fmt.Errorf("failed to marshal Build proto to JSON: %w", err)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, h.url, bytes.NewReader(jb))
 	if err != nil {
-		return fmt.Errorf("failed to create a new HTTP request: %v", err)
+		return fmt.Errorf("failed to create a new HTTP request: %w", err)
 	}
 
 	req.Header.Set("Content-Type", "application/json")
@@ -84,7 +84,7 @@ func (h *httpNotifier) SendNotification(ctx context.Context, build *cbpb.Build) 
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("failed to make HTTP request: %v", err)
+		return fmt.Errorf("failed to make HTTP request: %w", err)
 	}
 	defer resp.Body.Close()
 

--- a/slack/main.go
+++ b/slack/main.go
@@ -43,21 +43,21 @@ type slackNotifier struct {
 func (s *slackNotifier) SetUp(ctx context.Context, cfg *notifiers.Config, sg notifiers.SecretGetter) error {
 	prd, err := notifiers.MakeCELPredicate(cfg.Spec.Notification.Filter)
 	if err != nil {
-		return fmt.Errorf("failed to make a CEL predicate: %v", err)
+		return fmt.Errorf("failed to make a CEL predicate: %w", err)
 	}
 	s.filter = prd
 
 	wuRef, err := notifiers.GetSecretRef(cfg.Spec.Notification.Delivery, webhookURLSecretName)
 	if err != nil {
-		return fmt.Errorf("failed to get Secret ref from delivery config (%v) field %q: %v", cfg.Spec.Notification.Delivery, webhookURLSecretName, err)
+		return fmt.Errorf("failed to get Secret ref from delivery config (%v) field %q: %w", cfg.Spec.Notification.Delivery, webhookURLSecretName, err)
 	}
 	wuResource, err := notifiers.FindSecretResourceName(cfg.Spec.Secrets, wuRef)
 	if err != nil {
-		return fmt.Errorf("failed to find Secret for ref %q: %v", wuRef, err)
+		return fmt.Errorf("failed to find Secret for ref %q: %w", wuRef, err)
 	}
 	wu, err := sg.GetSecret(ctx, wuResource)
 	if err != nil {
-		return fmt.Errorf("failed to get token secret: %v", err)
+		return fmt.Errorf("failed to get token secret: %w", err)
 	}
 	s.webhookURL = wu
 
@@ -72,7 +72,7 @@ func (s *slackNotifier) SendNotification(ctx context.Context, build *cbpb.Build)
 	log.Infof("sending Slack webhook for Build %q (status: %q)", build.Id, build.Status)
 	msg, err := s.writeMessage(build)
 	if err != nil {
-		return fmt.Errorf("failed to write Slack message: %v", err)
+		return fmt.Errorf("failed to write Slack message: %w", err)
 	}
 
 	return slack.PostWebhook(s.webhookURL, msg)
@@ -98,7 +98,7 @@ func (s *slackNotifier) writeMessage(build *cbpb.Build) (*slack.WebhookMessage, 
 
 	logURL, err := notifiers.AddUTMParams(build.LogUrl, notifiers.ChatMedium)
 	if err != nil {
-		return nil, fmt.Errorf("failed to add UTM params: %v", err)
+		return nil, fmt.Errorf("failed to add UTM params: %w", err)
 	}
 
 	atch := slack.Attachment{


### PR DESCRIPTION
This uses the `%w` fmt verb to preserve underlying error information
when an error is returned. See https://blog.golang.org/go1.13-errors.

As a result, this means that GCB Notifiers requires Go >= 1.13.