### PR TITLE
Add major-latest tags to repository images.

### DIFF
--- a/http/deploy.cloudbuild.yaml
+++ b/http/deploy.cloudbuild.yaml
@@ -18,6 +18,7 @@ steps:
   args:
   - build
   - --tag=${_REGISTRY}/http:${TAG_NAME}
+  - --tag=${_REGISTRY}/http:${_MAJOR_LATEST}
   - --tag=${_REGISTRY}/http:latest
   - --file=./http/Dockerfile
   - '.'
@@ -30,10 +31,16 @@ steps:
 # Push the image with tags.
 images:
 - ${_REGISTRY}/http:${TAG_NAME}
+- ${_REGISTRY}/http:${_MAJOR_LATEST}
 - ${_REGISTRY}/http:latest
+
+options:
+  dynamic_substitutions: true
 
 substitutions:
   _REGISTRY: us-east1-docker.pkg.dev/gcb-release/cloud-build-notifiers
+  # Looks like: $NOTIF-$MAJOR-latest. Not meant for overriding.
+  _MAJOR_LATEST: "${TAG_NAME%%.*}-latest"
 
 tags:
 - cloud-build-notifiers-http

--- a/slack/deploy.cloudbuild.yaml
+++ b/slack/deploy.cloudbuild.yaml
@@ -18,6 +18,7 @@ steps:
   args:
   - build
   - --tag=${_REGISTRY}/slack:${TAG_NAME}
+  - --tag=${_REGISTRY}/slack:${_MAJOR_LATEST}
   - --tag=${_REGISTRY}/slack:latest
   - --file=./slack/Dockerfile
   - '.'
@@ -30,10 +31,16 @@ steps:
 # Push the image with tags.
 images:
 - ${_REGISTRY}/slack:${TAG_NAME}
+- ${_REGISTRY}/slack:${_MAJOR_LATEST}
 - ${_REGISTRY}/slack:latest
+
+options:
+  dynamic_substitutions: true
 
 substitutions:
   _REGISTRY: us-east1-docker.pkg.dev/gcb-release/cloud-build-notifiers
+  # Looks like: $NOTIF-$MAJOR-latest. Not meant for overriding.
+  _MAJOR_LATEST: "${TAG_NAME%%.*}-latest"
 
 tags:
 - cloud-build-notifiers-slack

--- a/smtp/deploy.cloudbuild.yaml
+++ b/smtp/deploy.cloudbuild.yaml
@@ -18,6 +18,7 @@ steps:
   args:
   - build
   - --tag=${_REGISTRY}/smtp:${TAG_NAME}
+  - --tag=${_REGISTRY}/smtp:${_MAJOR_LATEST}
   - --tag=${_REGISTRY}/smtp:latest
   - --file=./smtp/Dockerfile
   - '.'
@@ -30,10 +31,16 @@ steps:
 # Push the image with tags.
 images:
 - ${_REGISTRY}/smtp:${TAG_NAME}
+- ${_REGISTRY}/smtp:${_MAJOR_LATEST}
 - ${_REGISTRY}/smtp:latest
+
+options:
+  dynamic_substitutions: true
 
 substitutions:
   _REGISTRY: us-east1-docker.pkg.dev/gcb-release/cloud-build-notifiers
+  # Looks like: $NOTIF-$MAJOR-latest. Not meant for overriding.
+  _MAJOR_LATEST: "${TAG_NAME%%.*}-latest"
 
 tags:
 - cloud-build-notifiers-smtp


### PR DESCRIPTION
This adds an image tag derived from git tag `smtp-1.2.3` to `smtp-1-latest` for example.

No other existing tags are affected.