### PR TITLE
Add cb.yaml for lib/notifiers buildtest.

### DIFF
--- a/lib/notifiers/buildtest.cloudbuild.yaml
+++ b/lib/notifiers/buildtest.cloudbuild.yaml
@@ -1,0 +1,8 @@
+# Build and test lib/notifiers.
+steps:
+- name: golang
+  args: [go, build, --mod=readonly, '.']
+  env: [GO111MODULE=on]
+- name: golang
+  args: [go, test, --mod=readonly, '.']
+  env: [GO111MODULE=on]

--- a/lib/notifiers/buildtest.cloudbuild.yaml
+++ b/lib/notifiers/buildtest.cloudbuild.yaml
@@ -6,3 +6,4 @@ steps:
 - name: golang
   args: [go, test, --mod=readonly, '.']
   env: [GO111MODULE=on]
+  


### PR DESCRIPTION
Our other cb.yamls are triggered on changes to `lib/**` but they don't actually test it. I'll set up a PR trigger to run this specific cb.yaml.