### PR TITLE
Fix lib/notifiers buildtest trigger/cb.yaml.

### DIFF
--- a/lib/notifiers/Dockerfile
+++ b/lib/notifiers/Dockerfile
@@ -1,0 +1,19 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM golang AS build-env
+COPY . /go-src/
+WORKDIR /go-src/lib/notifiers
+RUN go test /go-src/lib/notifiers
+RUN go build -o /dev/null .

--- a/lib/notifiers/buildtest.cloudbuild.yaml
+++ b/lib/notifiers/buildtest.cloudbuild.yaml
@@ -1,9 +1,10 @@
 # Build and test lib/notifiers.
 steps:
-- name: golang
-  args: [go, build, --mod=readonly, '.']
-  env: [GO111MODULE=on]
-- name: golang
-  args: [go, test, --mod=readonly, '.']
-  env: [GO111MODULE=on]
-  
+- name: gcr.io/cloud-builders/docker
+  args:
+  - build
+  - --file=./lib/notifiers/Dockerfile
+  - '.'
+
+tags:
+- cloud-build-notifiers-lib-notifiers


### PR DESCRIPTION
Just use a Dockerfile to get around the directory traversing we have to
do, like with the other directories.

I tested this in another GCP project and did a docker build locally.