### PR TITLE
add api check and pub/sub topic check to setup script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -126,7 +126,7 @@ fail() {
 check_apis_enabled() {
   SERVICES=$(gcloud services list --enabled --format='value(config.title)')
   for API in "${REQUIRED_SERVICES[@]}"; do
-    echo "${SERVICES}" | grep "${API}" || fail "please enable the ${API}"
+    [ -z ${SERVICES[@]/*${API}*/} ] || fail "please enable the ${API}"
   done
 }
 

--- a/setup.sh
+++ b/setup.sh
@@ -41,8 +41,7 @@ For help/usage:
 ./setup.sh --help
 "
 
-
-main () {
+main() {
   # Simple argument checks.
   if [ "$*" = "--help" ]; then
     echo "${HELP}"
@@ -51,7 +50,6 @@ main () {
     fail "${HELP}"
   fi
 
-
   NOTIFIER_TYPE="$1"
   SOURCE_CONFIG_PATH="$2"
   SECRET_NAME="${3:-}" # Optional secret_name name.
@@ -59,8 +57,8 @@ main () {
   # Check that the user is using a supported notifier type in the correct
   # directory.
   case "${NOTIFIER_TYPE}" in
-  http|smtp|slack|bigquery) ;;
-  *) fail "${HELP}"
+  http | smtp | slack | bigquery) ;;
+  *) fail "${HELP}" ;;
   esac
 
   if [ ! -d "${NOTIFIER_TYPE}" ]; then
@@ -72,8 +70,8 @@ main () {
   fi
 
   # Project ID, assumed to NOT be org-scoped (only alphanumeric and dashes).
-  PROJECT_ID=$(gcloud config get-value project) \
-    || fail "could not get default project"
+  PROJECT_ID=$(gcloud config get-value project) ||
+    fail "could not get default project"
   if [ "${PROJECT_ID}" = "(unset)" ]; then
     fail "default project not set; run \"gcloud config set project <project_id>\"" \
       "or set the CLOUDSDK_CORE_PROJECT environment variable"
@@ -82,9 +80,10 @@ main () {
     fail "org-scoped project IDs are not allowed by this script"
   fi
   PROJECT_NUMBER=$(gcloud projects describe "${PROJECT_ID}" \
-    --format="value(projectNumber)") \
-    || fail "could not get project number"
+    --format="value(projectNumber)") ||
+    fail "could not get project number"
 
+  REQUIRED_SERVICES=('Cloud Build API' 'Cloud Run Admin API' 'Cloud Pub/Sub API' 'Secret Manager API')
   SOURCE_CONFIG_BASENAME=$(basename "${SOURCE_CONFIG_PATH}")
   DESTINATION_BUCKET_NAME="${PROJECT_ID}-notifiers-config"
   DESTINATION_BUCKET_URI="gs://${DESTINATION_BUCKET_NAME}"
@@ -119,82 +118,79 @@ main () {
   echo "** NOTIFIER SETUP COMPLETE **" 1>&2
 }
 
-fail () {
+fail() {
   echo "$*" 1>&2
   exit 1
 }
 
-check_apis_enabled () {
-  SERVICES=`gcloud services list --enabled`
-  for API in 'Cloud Build API' 'Cloud Run Admin API' 'Cloud Pub/Sub API' 'Secret Manager API';
-    do
-      if [[ ${SERVICES} != *${API}* ]]; then
-        fail "please enable the ${API}"
-      fi
-    done
+check_apis_enabled() {
+  SERVICES=$(gcloud services list --enabled --format='value(config.title)')
+  for API in "${REQUIRED_SERVICES[@]}"; do
+    echo "${SERVICES}" | grep "${API}" || fail "please enable the ${API}"
+  done
 }
 
-add_secret_name_accessor_permission () {
+add_secret_name_accessor_permission() {
   gcloud secrets add-iam-policy-binding "${SECRET_NAME}" \
     --member="serviceAccount:${PROJECT_NUMBER}-compute@developer.gserviceaccount.com" \
-    --role="roles/secretmanager.secretAccessor" \
-    || fail "failed to set up secret access"
+    --role="roles/secretmanager.secretAccessor" ||
+    fail "failed to set up secret access"
 }
 
-upload_config () {
+upload_config() {
   # We allow this `mb` command to error since we rely on the `cp` command hard-
   # erroring if there's an actual problem (since `mb` fails if the bucket
   # already exists).
   gsutil mb "${DESTINATION_BUCKET_URI}"
 
-  gsutil cp "${SOURCE_CONFIG_PATH}" "${DESTINATION_CONFIG_PATH}" \
-    || fail "failed to copy config to GCS"
+  gsutil cp "${SOURCE_CONFIG_PATH}" "${DESTINATION_CONFIG_PATH}" ||
+    fail "failed to copy config to GCS"
 }
 
-deploy_notifier () {
+deploy_notifier() {
   gcloud run deploy "${SERVICE_NAME}" \
     --image="${IMAGE_PATH}" \
     --no-allow-unauthenticated \
-    --update-env-vars="CONFIG_PATH=${DESTINATION_CONFIG_PATH},PROJECT_ID=${PROJECT_ID}" \
-    || fail "failed to deploy notifier service -- check service logs for configuration error"
+    --update-env-vars="CONFIG_PATH=${DESTINATION_CONFIG_PATH},PROJECT_ID=${PROJECT_ID}" ||
+    fail "failed to deploy notifier service -- check service logs for configuration error"
 }
 
-add_sa_token_creator_permission () {
+add_sa_token_creator_permission() {
   gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
     --member="serviceAccount:${PUBSUB_SA}" \
     --role="roles/iam.serviceAccountTokenCreator"
 }
 
-create_invoker_sa () {
+create_invoker_sa() {
   gcloud iam service-accounts create cloud-run-pubsub-invoker \
     --display-name "Cloud Run Pub/Sub Invoker"
 }
 
-add_invoker_permission () {
+add_invoker_permission() {
   gcloud run services add-iam-policy-binding "${SERVICE_NAME}" \
     --member="serviceAccount:${INVOKER_SA}" \
     --role=roles/run.invoker
 }
 
-create_pubsub_topic () {
+create_pubsub_topic() {
   gcloud pubsub topics create cloud-builds
 }
 
-check_pubsub_topic () {
-  gcloud pubsub topics describe cloud-builds \
-    || fail "expected the notifier Pub/Sub topic cloud-builds to exist"
+check_pubsub_topic() {
+  gcloud pubsub topics describe cloud-builds ||
+    fail "expected the notifier Pub/Sub topic cloud-builds to exist"
 }
 
-create_pubsub_subscription () {
+create_pubsub_subscription() {
   gcloud pubsub subscriptions create "${SUBSCRIPTION_NAME}" \
     --topic=cloud-builds \
     --push-endpoint="${SERVICE_URL}" \
     --push-auth-service-account="${INVOKER_SA}"
 }
 
-check_pubsub_subscription () {
-  gcloud pubsub subscriptions describe "${SUBSCRIPTION_NAME}" \
-    || fail "expected the notifier Pub/Sub subscription to exist"
+check_pubsub_subscription() {
+  gcloud pubsub subscriptions describe "${SUBSCRIPTION_NAME}" ||
+    fail "expected the notifier Pub/Sub subscription to exist"
 }
 
 main "$@"


### PR DESCRIPTION
We check for the cloud-builds pub/sub topic and create it in the case of nonexistence.

Upon any API required for the notifier ('Cloud Build API' 'Cloud Run Admin API' 'Cloud Pub/Sub API' 'Secret Manager API') not being enabled, we request the user to manually enable the API and terminate the script.

Formatted with the shell-format extension in vscode