### PR TITLE
Add ability to specify custom slack message template

### DIFF
--- a/slack/README.md
+++ b/slack/README.md
@@ -16,3 +16,7 @@ This notifier expects the following fields in the `delivery` map to be set:
 
 - `webhook_url`: The `secretRef: <Slack-webhook-URL>` map that references the
 Slack webhook URL resource path in the `secrets` section.
+
+- (optionally) `template`: Allows to define a custom message sent to slack.
+See go text/template for syntax, the data passed is the [Build](https://godoc.org/google.golang.org/genproto/googleapis/devtools/cloudbuild/v1#Build)
+resource.

--- a/slack/main_test.go
+++ b/slack/main_test.go
@@ -1,12 +1,21 @@
 package main
 
 import (
+	"context"
+	"github.com/GoogleCloudPlatform/cloud-build-notifiers/lib/notifiers"
 	"testing"
+	"text/template"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/slack-go/slack"
 	cbpb "google.golang.org/genproto/googleapis/devtools/cloudbuild/v1"
 )
+
+type dummySecretGetter struct{}
+
+func (d *dummySecretGetter) GetSecret(_ context.Context, _ string) (string, error) {
+	return "", nil
+}
 
 func TestWriteMessage(t *testing.T) {
 	n := new(slackNotifier)
@@ -16,6 +25,8 @@ func TestWriteMessage(t *testing.T) {
 		Status:    cbpb.Build_SUCCESS,
 		LogUrl:    "https://some.example.com/log/url?foo=bar",
 	}
+	tpl, _ := template.New("slack_message").Parse(fallbackTemplate)
+	n.tmpl = tpl
 
 	got, err := n.writeMessage(b)
 	if err != nil {
@@ -36,5 +47,48 @@ func TestWriteMessage(t *testing.T) {
 
 	if diff := cmp.Diff(got, want); diff != "" {
 		t.Errorf("writeMessage got unexpected diff: %s", diff)
+	}
+}
+
+func TestWriteTplMessage(t *testing.T) {
+	n := new(slackNotifier)
+	b := &cbpb.Build{
+		ProjectId: "my-project-id",
+	}
+
+	cfg := &notifiers.Config{
+		Spec: &notifiers.Spec{
+			Notification: &notifiers.Notification{
+				Filter: "build.status == Build.Status.SUCCESS",
+				Delivery: map[string]interface{}{
+					"template": "custom tpl: {{ .ProjectId }}",
+					"webhookUrl": map[interface{}]interface{}{
+						"secretRef": "ref",
+					},
+				},
+			},
+			Secrets: []*notifiers.Secret{
+				{LocalName: "ref", ResourceName: ""},
+			},
+		},
+	}
+	err := n.SetUp(context.Background(), cfg, new(dummySecretGetter))
+	if err != nil {
+		t.Fatalf("failed to setup notifier: %v", err)
+	}
+
+	got, err := n.writeMessage(b)
+	if err != nil {
+		t.Fatalf("writeMessage failed: %v", err)
+	}
+
+	if len(got.Attachments) == 0 {
+		t.Fatalf("unexpected slack message structure")
+	}
+
+	actual := got.Attachments[0].Text
+	want := "custom tpl: my-project-id"
+	if actual != want {
+		t.Errorf("wanted slack message text '%s', got '%s'", want, actual)
 	}
 }

--- a/slack/slack.yaml.example
+++ b/slack/slack.yaml.example
@@ -20,6 +20,7 @@ spec:
   notification:
     filter: build.status == Build.Status.SUCCESS
     delivery:
+      template: "Cloud Build ({{ .ProjectId }}, {{ .Id }}): {{ .Status }}"
       webhookUrl:
         secretRef: webhook-url
   secrets:


### PR DESCRIPTION
Provides users more flexibility to define their own templates, for
example - including a repository for which the build happened.

A user optionally can define a `template` under delivery map. If its not
defined it falls back to current message. Data passed - the cloudbuild
`Build` Resource.

Closes #32 