### PR TITLE
Add support for HTTP Bearer Token authentication

### DIFF
--- a/http/README.md
+++ b/http/README.md
@@ -16,3 +16,5 @@ This notifier expects the following fields in the `delivery` map to be set:
 
 - `url`: The HTTP endpoint to which `POST` requests will be sent. No sort of
 authentication is expected or used.
+- `authentication`: The reference to a configuration in the `secrets` list.
+  This field is optional, if set, a Bearer token is expected.

--- a/http/http.yaml.example
+++ b/http/http.yaml.example
@@ -22,3 +22,9 @@ spec:
     delivery:
       # The `http(s)://` protocol prefix is required.
       url: https://some.example.com/notify
+      # The following is optional
+      authentication:
+        secretRef: http-auth
+  secrets:
+  - name: http-auth
+    value: projects/<Project ID>/secrets/<Secret Name>/versions/latest


### PR DESCRIPTION
This follows the same configuration format as the SMTP notifier