### PR TITLE
Fix color in Slack Notifier

### DIFF
--- a/slack/main.go
+++ b/slack/main.go
@@ -108,9 +108,12 @@ func (s *slackNotifier) writeMessage() (*slack.WebhookMessage, error) {
 	var clr string
 	switch build.Status {
 	case cbpb.Build_SUCCESS:
-		clr = "good"
-	case cbpb.Build_FAILURE, cbpb.Build_INTERNAL_ERROR, cbpb.Build_TIMEOUT:
-		clr = "danger"
+		// https://stackoverflow.com/q/70039333
+		clr = "#2EB67D"  // green
+	case cbpb.Build_FAILURE:
+		clr = "#ff0000"  // red
+	case cbpb.Build_INTERNAL_ERROR, cbpb.Build_TIMEOUT:
+		clr = "#ECB22E"  // yeallow
 	default:
 		clr = "warning"
 	}
@@ -126,5 +129,11 @@ func (s *slackNotifier) writeMessage() (*slack.WebhookMessage, error) {
 		return nil, fmt.Errorf("failed to unmarshal templating JSON: %w", err)
 	}
 
-	return &slack.WebhookMessage{Attachments: []slack.Attachment{{Color: clr}}, Blocks: &blocks}, nil
+	// https://api.slack.com/reference/messaging/attachments#fields
+	atch := slack.Attachment{
+		Color: clr,
+		Blocks: blocks,
+	}
+
+    return &slack.WebhookMessage{Attachments: []slack.Attachment{atch}}, nil
 }

--- a/slack/main_test.go
+++ b/slack/main_test.go
@@ -61,36 +61,36 @@ func TestWriteMessage(t *testing.T) {
 	}
 
 	want := &slack.WebhookMessage{
-		Attachments: []slack.Attachment{{Color: "good"}},
-		Blocks: &slack.Blocks{
-			BlockSet: []slack.Block{
-				&slack.SectionBlock{
-					Type: "section",
-					Text: &slack.TextBlockObject{
-						Type: "mrkdwn",
-						Text: "Build Status: SUCCESS",
+		Attachments: []slack.Attachment{{
+			Color: "#2EB67D",
+			Blocks: slack.Blocks{
+				BlockSet: []slack.Block{
+					&slack.SectionBlock{
+						Type: "section",
+						Text: &slack.TextBlockObject{
+							Type: "mrkdwn",
+							Text: "Build Status: SUCCESS",
+						},
+					},
+					&slack.DividerBlock{
+						Type: "divider",
+					},
+					&slack.SectionBlock{
+						Type: "section",
+						Text: &slack.TextBlockObject{
+							Type: "mrkdwn",
+							Text: "View Build Logs",
+						},
+						Accessory: &slack.Accessory{ButtonElement: &slack.ButtonBlockElement{
+							Type:     "button",
+							Text:     &slack.TextBlockObject{Type: "plain_text", Text: "Logs"},
+							ActionID: "button-action",
+							URL:      "https://some.example.com/log/url?foo=bar",
+							Value:    "click_me_123",
+						}},
 					},
 				},
-				&slack.DividerBlock{
-					Type: "divider",
-				},
-				&slack.SectionBlock{
-					Type: "section",
-					Text: &slack.TextBlockObject{
-						Type: "mrkdwn",
-						Text: "View Build Logs",
-					},
-					Accessory: &slack.Accessory{ButtonElement: &slack.ButtonBlockElement{
-						Type:     "button",
-						Text:     &slack.TextBlockObject{Type: "plain_text", Text: "Logs"},
-						ActionID: "button-action",
-						URL:      "https://some.example.com/log/url?foo=bar",
-						Value:    "click_me_123",
-					}},
-				},
-			},
-		},
-	}
+			}}}}
 
 	if diff := cmp.Diff(got, want); diff != "" {
 		t.Errorf("writeMessage got unexpected diff: %s", diff)


### PR DESCRIPTION
`color` should be passed into `attachments` array.
https://api.slack.com/reference/messaging/attachments#fields

## Example

### Before fix

<img width="679" alt="image" src="https://user-images.githubusercontent.com/433434/171629076-3ab02d92-f252-4698-8a89-fe1b38753eb8.png">

### After fix

<img width="677" alt="image" src="https://user-images.githubusercontent.com/433434/171628931-7ae72f54-639e-4192-8c7f-d009d6a2e1cf.png">