### PR TITLE
slack: Add block color context

### DIFF
--- a/slack/main.go
+++ b/slack/main.go
@@ -105,14 +105,15 @@ func (s *slackNotifier) writeMessage() (*slack.WebhookMessage, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to add UTM params: %w", err)
 	}
+
 	var clr string
 	switch build.Status {
 	case cbpb.Build_SUCCESS:
-		clr = "good"
+		clr = "#22bb33"
 	case cbpb.Build_FAILURE, cbpb.Build_INTERNAL_ERROR, cbpb.Build_TIMEOUT:
-		clr = "danger"
+		clr = "#bb2124"
 	default:
-		clr = "warning"
+		clr = "#f0ad4e"
 	}
 
 	var buf bytes.Buffer

--- a/slack/main.go
+++ b/slack/main.go
@@ -126,5 +126,5 @@ func (s *slackNotifier) writeMessage() (*slack.WebhookMessage, error) {
 		return nil, fmt.Errorf("failed to unmarshal templating JSON: %w", err)
 	}
 
-	return &slack.WebhookMessage{Attachments: []slack.Attachment{{Color: clr}}, Blocks: &blocks}, nil
+	return &slack.WebhookMessage{Attachments: []slack.Attachment{{Color: clr, Blocks: blocks}}}, nil
 }

--- a/slack/main_test.go
+++ b/slack/main_test.go
@@ -61,35 +61,37 @@ func TestWriteMessage(t *testing.T) {
 	}
 
 	want := &slack.WebhookMessage{
-		Attachments: []slack.Attachment{{Color: "good"}},
-		Blocks: &slack.Blocks{
-			BlockSet: []slack.Block{
-				&slack.SectionBlock{
-					Type: "section",
-					Text: &slack.TextBlockObject{
-						Type: "mrkdwn",
-						Text: "Build Status: SUCCESS",
+		Attachments: []slack.Attachment{{
+			Color: "good",
+			Blocks: slack.Blocks{
+				BlockSet: []slack.Block{
+					&slack.SectionBlock{
+						Type: "section",
+						Text: &slack.TextBlockObject{
+							Type: "mrkdwn",
+							Text: "Build Status: SUCCESS",
+						},
 					},
-				},
-				&slack.DividerBlock{
-					Type: "divider",
-				},
-				&slack.SectionBlock{
-					Type: "section",
-					Text: &slack.TextBlockObject{
-						Type: "mrkdwn",
-						Text: "View Build Logs",
+					&slack.DividerBlock{
+						Type: "divider",
 					},
-					Accessory: &slack.Accessory{ButtonElement: &slack.ButtonBlockElement{
-						Type:     "button",
-						Text:     &slack.TextBlockObject{Type: "plain_text", Text: "Logs"},
-						ActionID: "button-action",
-						URL:      "https://some.example.com/log/url?foo=bar",
-						Value:    "click_me_123",
-					}},
+					&slack.SectionBlock{
+						Type: "section",
+						Text: &slack.TextBlockObject{
+							Type: "mrkdwn",
+							Text: "View Build Logs",
+						},
+						Accessory: &slack.Accessory{ButtonElement: &slack.ButtonBlockElement{
+							Type:     "button",
+							Text:     &slack.TextBlockObject{Type: "plain_text", Text: "Logs"},
+							ActionID: "button-action",
+							URL:      "https://some.example.com/log/url?foo=bar",
+							Value:    "click_me_123",
+						}},
+					},
 				},
 			},
-		},
+		}},
 	}
 
 	if diff := cmp.Diff(got, want); diff != "" {

--- a/slack/main_test.go
+++ b/slack/main_test.go
@@ -62,7 +62,7 @@ func TestWriteMessage(t *testing.T) {
 
 	want := &slack.WebhookMessage{
 		Attachments: []slack.Attachment{{
-			Color: "good",
+			Color: "#22bb33",
 			Blocks: slack.Blocks{
 				BlockSet: []slack.Block{
 					&slack.SectionBlock{


### PR DESCRIPTION
The PR provides a small fix to the slack message sent by cloud build.

The two commits have a detailed commit message so I will avoid duplication here.