### PR TITLE
New notifier - GitHub Issues

### DIFF
--- a/githubissues/Dockerfile
+++ b/githubissues/Dockerfile
@@ -1,0 +1,33 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM golang AS build-env
+COPY . /go-src/
+WORKDIR /go-src/githubissues
+RUN go test /go-src/githubissues
+RUN go build -o /go-app .
+
+# From the Cloud Run docs:
+# https://cloud.google.com/run/docs/tutorials/pubsub#looking_at_the_code
+# Use the official Debian slim image for a lean production container.
+# https://hub.docker.com/_/debian
+# https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
+FROM debian:buster-slim
+RUN set -x && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+FROM gcr.io/distroless/base
+COPY --from=build-env /go-app /
+ENTRYPOINT ["/go-app", "--alsologtostderr", "--v=0"]

--- a/githubissues/README.md
+++ b/githubissues/README.md
@@ -1,0 +1,21 @@
+# Cloud Build GitHub Issues Notifier
+
+This notifier uses [GitHub Webhooks](https://docs.github.com/en/developers/webhooks-and-events/webhooks/creating-webhooks) to
+create issues against your GitHub repo.
+
+This notifier runs as a container via Google Cloud Run and responds to
+events that Cloud Build publishes via its
+[Pub/Sub topic](https://cloud.google.com/cloud-build/docs/send-build-notifications).
+
+For detailed instructions on setting up this notifier,
+see [Configuring GitHub Issue notifications](https://cloud.google.com/cloud-build/docs/configuring-notifications/configure-githubissues).
+
+## Configuration Variables
+
+This notifier expects the following fields in the `delivery` map to be set:
+
+- `githubRepo`: The name of the repo to create an issue against (e.g. `youruser/yourrepo`)
+- `githubToken`: The `secretRef: <github-token>` map that references the GitHub Issue token resource path in the `secrets` section.
+
+This notifier also takes a custom `template` that can either be set inline, or as a uri, as a
+JSON object specifying at minimum the customisable `title` and `body` (in Markdown) of the issue. See [GitHub's REST documentation](https://docs.github.com/en/rest/issues/issues#create-an-issue) for more body parameters. See TODO for more on templates.

--- a/githubissues/buildtest.cloudbuild.yaml
+++ b/githubissues/buildtest.cloudbuild.yaml
@@ -1,0 +1,23 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+- name: gcr.io/cloud-builders/docker
+  args:
+  - build
+  - --file=./githubissues/Dockerfile
+  - '.'
+
+tags:
+- cloud-build-notifiers-githubissues

--- a/githubissues/deploy.cloudbuild.yaml
+++ b/githubissues/deploy.cloudbuild.yaml
@@ -1,0 +1,47 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+# Build the binary and put it into the builder image.
+- name: gcr.io/cloud-builders/docker
+  args:
+  - build
+  - --tag=${_REGISTRY}/githubissues:${TAG_NAME}
+  - --tag=${_REGISTRY}/githubissues:${_MAJOR_LATEST}
+  - --tag=${_REGISTRY}/githubissues:latest
+  - --file=./githubissues/Dockerfile
+  - '.'
+# Run the smoketest to verify that everything built correctly.
+- name: ${_REGISTRY}/githubissues:${TAG_NAME}
+  args:
+  - --smoketest
+  - --alsologtostderr
+
+# Push the image with tags.
+images:
+- ${_REGISTRY}/githubissues:${TAG_NAME}
+- ${_REGISTRY}/githubissues:${_MAJOR_LATEST}
+- ${_REGISTRY}/githubissues:latest
+
+options:
+  dynamic_substitutions: true
+
+substitutions:
+  _REGISTRY: us-east1-docker.pkg.dev/gcb-release/cloud-build-notifiers
+  # Looks like: $NOTIF-$MAJOR-latest. Not meant for overriding.
+  _MAJOR_LATEST: "${TAG_NAME%%.*}-latest"
+
+tags:
+- cloud-build-notifiers-githubissues
+- githubissues-${TAG_NAME}

--- a/githubissues/githubissues.json
+++ b/githubissues/githubissues.json
@@ -2,3 +2,4 @@
     "title": "Cloud Build [{{.Build.ProjectId}}] {{.Build.BuildTriggerId}}: {{.Build.Status}}",
     "body": "Cloud Build {{.Build.ProjectId}} {{.Build.BuildTriggerId}} status: **{{.Build.Status}}**\n\n[View Logs]({{.Build.LogUrl}})"
 }
+

--- a/githubissues/githubissues.json
+++ b/githubissues/githubissues.json
@@ -1,0 +1,4 @@
+{
+    "title": "Cloud Build [{{.Build.ProjectId}}] {{.Build.BuildTriggerId}}: {{.Build.Status}}",
+    "body": "Cloud Build {{.Build.ProjectId}} {{.Build.BuildTriggerId}} status: **{{.Build.Status}}**\n\n[View Logs]({{.Build.LogUrl}})"
+}

--- a/githubissues/githubissues.yaml.example
+++ b/githubissues/githubissues.yaml.example
@@ -1,0 +1,31 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: cloud-build-notifiers/v1
+kind: GitHubIssuesNotifier
+metadata:
+  name: example-githubissues-notifier
+spec:
+  notification:
+    filter: build.status == Build.Status.FAILURE
+    template: 
+      type: golang
+      uri: gs://project-name/githuissues.json
+    delivery:
+      githubToken:
+        secretRef: github-token
+      githubRepo: myuser/myrepo
+  secrets:
+  - name: github-token
+    value: projects/example-project/secrets/example-github-token/versions/latest

--- a/githubissues/githubissues.yaml.example
+++ b/githubissues/githubissues.yaml.example
@@ -21,7 +21,7 @@ spec:
     filter: build.status == Build.Status.FAILURE
     template: 
       type: golang
-      uri: gs://project-name/githuissues.json
+      uri: gs://project-name/githubissues.json
     delivery:
       githubToken:
         secretRef: github-token

--- a/githubissues/main.go
+++ b/githubissues/main.go
@@ -1,0 +1,150 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"text/template"
+
+	"github.com/GoogleCloudPlatform/cloud-build-notifiers/lib/notifiers"
+	log "github.com/golang/glog"
+
+	cbpb "google.golang.org/genproto/googleapis/devtools/cloudbuild/v1"
+)
+
+const (
+	githubTokenSecretName = "githubToken"
+	githubApiEndpoint     = "https://api.github.com/repos"
+)
+
+func main() {
+	if err := notifiers.Main(new(githubissuesNotifier)); err != nil {
+		log.Fatalf("fatal error: %v", err)
+	}
+}
+
+type githubissuesNotifier struct {
+	filter      notifiers.EventFilter
+	tmpl        *template.Template
+	githubToken string
+	githubRepo  string
+
+	br       notifiers.BindingResolver
+	tmplView *notifiers.TemplateView
+}
+
+type githubissuesMessage struct {
+	Title string              `json:"title"`
+	Body  *notifiers.Template `json:"body"`
+}
+
+func (g *githubissuesNotifier) SetUp(ctx context.Context, cfg *notifiers.Config, issueTemplate string, sg notifiers.SecretGetter, br notifiers.BindingResolver) error {
+	prd, err := notifiers.MakeCELPredicate(cfg.Spec.Notification.Filter)
+	if err != nil {
+		return fmt.Errorf("failed to make a CEL predicate: %w", err)
+	}
+	g.filter = prd
+	g.br = br
+
+	repo, ok := cfg.Spec.Notification.Delivery["githubRepo"].(string)
+	if !ok {
+		return fmt.Errorf("expected delivery config %v to have string field `githubRepo`", cfg.Spec.Notification.Delivery)
+	}
+	g.githubRepo = repo
+
+	tmpl, err := template.New("issue_template").Parse(issueTemplate)
+	if err != nil {
+		return fmt.Errorf("failed to parse issue body template: %w", err)
+	}
+	g.tmpl = tmpl
+
+	wuRef, err := notifiers.GetSecretRef(cfg.Spec.Notification.Delivery, githubTokenSecretName)
+	if err != nil {
+		return fmt.Errorf("failed to get Secret ref from delivery config (%v) field %q: %w", cfg.Spec.Notification.Delivery, githubTokenSecretName, err)
+	}
+	wuResource, err := notifiers.FindSecretResourceName(cfg.Spec.Secrets, wuRef)
+	if err != nil {
+		return fmt.Errorf("failed to find Secret for ref %q: %w", wuRef, err)
+	}
+	wu, err := sg.GetSecret(ctx, wuResource)
+	if err != nil {
+		return fmt.Errorf("failed to get token secret: %w", err)
+	}
+	g.githubToken = wu
+
+	return nil
+}
+
+func (g *githubissuesNotifier) SendNotification(ctx context.Context, build *cbpb.Build) error {
+	if !g.filter.Apply(ctx, build) {
+		log.V(2).Infof("not sending response for event (build id = %s, status = %v)", build.Id, build.Status)
+		return nil
+	}
+
+	webhookURL := fmt.Sprintf("%s/%s/issues", githubApiEndpoint, g.githubRepo)
+
+	log.Infof("sending GitHub Issue webhook for Build %q (status: %q) to url %q", build.Id, build.Status, webhookURL)
+
+	bindings, err := g.br.Resolve(ctx, nil, build)
+	if err != nil {
+		log.Errorf("failed to resolve bindings :%v", err)
+	}
+	g.tmplView = &notifiers.TemplateView{
+		Build:  &notifiers.BuildView{Build: build},
+		Params: bindings,
+	}
+	logURL, err := notifiers.AddUTMParams(build.LogUrl, notifiers.HTTPMedium)
+	if err != nil {
+		return fmt.Errorf("failed to add UTM params: %w", err)
+	}
+	build.LogUrl = logURL
+
+	payload := new(bytes.Buffer)
+	var buf bytes.Buffer
+	if err := g.tmpl.Execute(&buf, g.tmplView); err != nil {
+		return err
+	}
+	err = json.NewEncoder(payload).Encode(buf)
+	if err != nil {
+		return fmt.Errorf("failed to encode payload: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, webhookURL, strings.NewReader(buf.String()))
+	if err != nil {
+		return fmt.Errorf("failed to create a new HTTP request: %w", err)
+	}
+
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+	req.Header.Set("Authorization", fmt.Sprintf("token %s", g.githubToken))
+	req.Header.Set("User-Agent", "GCB-Notifier/0.1 (http)")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to make HTTP request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		log.Warningf("got a non-OK response status %q (%d) from %q", resp.Status, resp.StatusCode, webhookURL)
+	}
+
+	log.V(2).Infoln("send HTTP request successfully")
+	return nil
+}

--- a/githubissues/main_test.go
+++ b/githubissues/main_test.go
@@ -1,0 +1,163 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"text/template"
+
+	"github.com/GoogleCloudPlatform/cloud-build-notifiers/lib/notifiers"
+	cbpb "google.golang.org/genproto/googleapis/devtools/cloudbuild/v1"
+)
+
+const githubToken = "ghtABC="
+
+type fakeSecretGetter struct{}
+
+func (f *fakeSecretGetter) GetSecret(_ context.Context, _ string) (string, error) {
+	return githubToken, nil
+}
+
+const issuePayload = `
+{
+    "title": "Cloud Build [{{.Build.ProjectId}}]: {{.Build.Status}}",
+    "body": "Cloud Build {{.Build.ProjectId}} {{.Build.BuildTriggerId}} status: **{{.Build.Status}}**\n\n[View Logs]({{.Build.LogUrl}})"
+}`
+
+func TestDefaultIssueTempate(t *testing.T) {
+
+	tmpl, err := template.New("issue_template").Parse(issuePayload)
+	if err != nil {
+		t.Fatalf("template.Parse failed: %v", err)
+	}
+	build := &cbpb.Build{
+		ProjectId: "my-project-id",
+		Id:        "some-build-id",
+		Status:    cbpb.Build_SUCCESS,
+		LogUrl:    "https://some.example.com/log/url?foo=bar",
+	}
+
+	view := &notifiers.TemplateView{
+		Build: &notifiers.BuildView{
+			Build: build,
+		},
+		Params: map[string]string{"buildStatus": "SUCCESS"},
+	}
+
+	body := new(bytes.Buffer)
+	if err := tmpl.Execute(body, view); err != nil {
+		t.Fatalf("failed to execute template: %v", err)
+	}
+
+	if !strings.Contains(body.String(), `SUCCESS`) {
+		t.Error("missing status")
+	}
+
+}
+
+func TestConfigs(t *testing.T) {
+	const repo = "somename/somerepo"
+	goodDelivery := map[string]interface{}{
+		"githubToken": map[interface{}]interface{}{"secretRef": "mytoken"},
+		"githubRepo":  repo,
+	}
+	goodSecret := []*notifiers.Secret{{LocalName: "mytoken", ResourceName: "mysekrit"}}
+
+	for _, tc := range []struct {
+		name    string
+		cfg     *notifiers.Config
+		wantErr bool
+	}{{
+		name: "valid config",
+		cfg: &notifiers.Config{
+			Spec: &notifiers.Spec{
+				Notification: &notifiers.Notification{
+					Filter:   `build.status == Build.Status.SUCCESS`,
+					Delivery: goodDelivery,
+				},
+				Secrets: goodSecret,
+			},
+		},
+	}, {
+		name: "missing filter",
+		cfg: &notifiers.Config{
+			Spec: &notifiers.Spec{
+				Notification: &notifiers.Notification{
+					Delivery: goodDelivery,
+				},
+				Secrets: goodSecret,
+			},
+		},
+		wantErr: true,
+	}, {
+		name: "bad filter",
+		cfg: &notifiers.Config{
+			Spec: &notifiers.Spec{
+				Notification: &notifiers.Notification{
+					Filter:   "blah-#B A D#-",
+					Delivery: goodDelivery,
+				},
+				Secrets: goodSecret,
+			},
+		},
+		wantErr: true,
+	}, {
+		name: "missing delivery repo",
+		cfg: &notifiers.Config{
+			Spec: &notifiers.Spec{
+				Notification: &notifiers.Notification{
+					Filter: `build.status == Build.Status.SUCCESS`,
+					Delivery: map[string]interface{}{
+						"githubToken": map[interface{}]interface{}{"secretRef": "mytoken"},
+					},
+				},
+				Secrets: goodSecret,
+			},
+		},
+		wantErr: true,
+	}, {
+		name: "missing secret",
+		cfg: &notifiers.Config{
+			Spec: &notifiers.Spec{
+				Notification: &notifiers.Notification{
+					Filter: `build.status == Build.Status.SUCCESS`,
+					Delivery: map[string]interface{}{
+						"githubRepo": repo,
+					},
+				},
+			},
+		},
+		wantErr: true,
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			n := new(githubissuesNotifier)
+			err := n.SetUp(context.Background(), tc.cfg, "", new(fakeSecretGetter), nil)
+			if err != nil {
+				if tc.wantErr {
+					t.Logf("got expected error: %v", err)
+					return
+				}
+				t.Fatalf("SetUp(%v) got unexpected error: %v", tc.cfg, err)
+			}
+
+			if tc.wantErr {
+				t.Error("unexpected success")
+			}
+		})
+	}
+}


### PR DESCRIPTION
b/229753500

<img width="922" alt="Preview of New GitHub Issues Notifier" src="https://user-images.githubusercontent.com/813732/176815345-42207e55-0dd1-48a0-8d57-c0b46003123c.png">

This notifier creates an issue against the configured GitHub repo. It also uses the new template feature to allow full customisation of the notification format, including GitHub features like labels and assignees (as shown in the screenshot). 