### PR TITLE
prevent invalid pubsub subscription names

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -130,6 +130,7 @@ main() {
   PUBSUB_SA="service-${PROJECT_NUMBER}@gcp-sa-pubsub.iam.gserviceaccount.com"
 
   # Edge case: pubsub subscriptions cannot start with certain strings.
+  # https://cloud.google.com/pubsub/docs/admin#resource_names
   if [ "${NOTIFIER_TYPE}" = "googlechat" ]; then
     SUBSCRIPTION_NAME="sub-${SUBSCRIPTION_NAME}"
   fi

--- a/setup.sh
+++ b/setup.sh
@@ -129,6 +129,11 @@ main() {
   INVOKER_SA="cloud-run-pubsub-invoker@${PROJECT_ID}.iam.gserviceaccount.com"
   PUBSUB_SA="service-${PROJECT_NUMBER}@gcp-sa-pubsub.iam.gserviceaccount.com"
 
+  # Edge case: pubsub subscriptions cannot start with certain strings.
+  if [ "${NOTIFIER_TYPE}" = "googlechat" ]; then
+    SUBSCRIPTION_NAME="sub-${SUBSCRIPTION_NAME}"
+  fi
+
   # Turn on command echoing after all of the variables have been set so we
   # don't log spam unnecessarily.
   set -x


### PR DESCRIPTION
Pub/Sub subscription and topic names cannot start with "goog"

https://cloud.google.com/pubsub/docs/admin#resource_names 

This change prepends if the notifier type is "googlechat"