### PR TITLE
Fix validation of GCS bucket names

### DIFF
--- a/lib/notifiers/notifiers.go
+++ b/lib/notifiers/notifiers.go
@@ -67,7 +67,7 @@ var (
 )
 
 var (
-	gcsConfigPattern = regexp.MustCompile(`^gs://([[\w-]+)/([^\\]+$)`)
+	gcsConfigPattern = regexp.MustCompile(`^gs://([[\w-_.]+)/([^\\]+$)`)
 )
 
 // Config is the common type for (YAML-based) configuration files for notifications.

--- a/lib/notifiers/notifiers_test.go
+++ b/lib/notifiers/notifiers_test.go
@@ -302,7 +302,10 @@ func TestGetGCSConfig(t *testing.T) {
 	validYAML := strings.ReplaceAll(validConfigYAMLWithTabs, "\t", "    " /* 4 spaces */)
 	validFakeFactory := &fakeGCSReaderFactory{
 		data: map[string]string{
-			"gs://path/to/my/config.yaml": validYAML,
+			"gs://path/to/my/config.yaml":                 validYAML,
+			"gs://bucket-with-dash/dir/config.yaml":       validYAML,
+			"gs://bucket.with.dot/dir/config.yaml":        validYAML,
+			"gs://bucket_with_underscore/dir/config.yaml": validYAML,
 		},
 	}
 
@@ -319,6 +322,22 @@ func TestGetGCSConfig(t *testing.T) {
 			fake:       validFakeFactory,
 			wantConfig: validConfig,
 		}, {
+			name:       "valid and present config in bucket with dashes",
+			path:       "gs://bucket-with-dash/dir/config.yaml",
+			fake:       validFakeFactory,
+			wantConfig: validConfig,
+		}, {
+			name:       "valid and present config in bucket with dots",
+			path:       "gs://bucket.with.dot/dir/config.yaml",
+			fake:       validFakeFactory,
+			wantConfig: validConfig,
+		}, {
+			name:       "valid and present config in bucket with underscores",
+			path:       "gs://bucket_with_underscore/dir/config.yaml",
+			fake:       validFakeFactory,
+			wantConfig: validConfig,
+		}, {
+
 			name:      "bad path",
 			path:      "gs://path/to/nowhere.yaml",
 			fake:      validFakeFactory,


### PR DESCRIPTION
PR #131 added validation of config paths. Unfortunately, the validation was incorrect.

The regex from the PR: `^gs://([[\w-]+)/([^\\]+$)`

This allows the bucket name to be word characters and `-`. I.e. `config-42-example-com`.
In reality `_` and `.` is also allowed! (see https://cloud.google.com/storage/docs/buckets#naming)

Our company prefers DNS style buckets, i.e., `config.example.com`, so this change just broke our use of the build-notifiers
