### PR TITLE
add booster-dashboard notification

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -205,6 +205,7 @@ deploy_notifier() {
   gcloud run deploy "${SERVICE_NAME}" \
     --image="${IMAGE_PATH}" \
     --no-allow-unauthenticated \
+    --max-instances=1 \
     --update-env-vars="CONFIG_PATH=${DESTINATION_CONFIG_PATH},PROJECT_ID=${PROJECT_ID}" ||
     fail "failed to deploy notifier service -- check service logs for configuration error"
 }

--- a/slack/slack-booster-dashboard.json
+++ b/slack/slack-booster-dashboard.json
@@ -1,0 +1,54 @@
+[
+  {
+    "type": "section",
+    "text": {
+      "type": "mrkdwn",
+      "text": "Cloud Build build state *{{.Params.buildStatus}}*. {{ if eq .Params.buildStatus `SUCCESS` }}✅{{ else }}❌{{ end }}"
+    }
+  },
+  {
+    "type": "section",
+    "text": {
+      "type": "mrkdwn",
+      "text": "*Trigger:* {{.Params.buildTriggerName}}"
+    }
+  },
+  {
+    "type": "section",
+    "fields": [
+      {
+        "type": "mrkdwn",
+        "text": "*ProjectId:*\n{{.Build.ProjectId}}"
+      },
+      {
+        "type": "mrkdwn",
+        "text": "*Repository:*\n{{.Params.buildRepository}}"
+      },
+      {
+        "type": "mrkdwn",
+        "text": "*Branch:*\n{{.Params.buildBranch}}"
+      },
+      {
+        "type": "mrkdwn",
+        "text": "*Commit:*\n{{.Params.buildCommit}}"
+      }
+    ]
+  },
+  {
+    "type": "divider"
+  },
+  {
+    "type": "actions",
+    "elements": [
+      {
+        "type": "button",
+        "text": {
+          "type": "plain_text",
+          "text": "View Build Logs"
+        },
+        "value": "click_me_123",
+        "url": "{{.Build.LogUrl}}"
+      }
+    ]
+  }
+]

--- a/slack/slack-booster-dashboard.yaml
+++ b/slack/slack-booster-dashboard.yaml
@@ -1,0 +1,37 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: cloud-build-notifiers/v1
+kind: SlackNotifier
+metadata:
+  name: cloudbuid-slack-notifier
+spec:
+  notification:
+    filter: build.status in [Build.Status.SUCCESS, Build.Status.FAILURE, Build.Status.INTERNAL_ERROR, Build.Status.TIMEOUT]
+    params: 
+      buildStatus: $(build.status)
+      buildTriggerName: $(build.substitutions['TRIGGER_NAME'])
+      buildRepository: $(build.substitutions['REPO_NAME'])
+      buildBranch: $(build.substitutions['BRANCH_NAME'])
+      buildCommit: $(build.substitutions['SHORT_SHA'])
+    delivery:
+      webhookUrl:
+        secretRef: webhook-url
+    template:
+      type: golang
+      uri: gs://repro-booster-production-notifiers-config/slack.json
+  secrets:
+  - name: webhook-url
+    value: projects/example-project/secrets/example-slack-notifier-webhook-url/versions/latest
+    value: projects/repro-booster-production/secrets/cloudbuild_slack_notifier_webhook_url/versions/latest


### PR DESCRIPTION
Booster Dashboard 用の通知設定を追加する

参考
- https://tech.toreta.in/entry/2022/12/22/notify-slack-of-cloud-build-results
- https://cloud.google.com/build/docs/configuring-notifications/configure-slack
