### PR TITLE
Added a template function 'replace' to BlockKitTemplate parser

### DIFF
--- a/slack/README.md
+++ b/slack/README.md
@@ -27,3 +27,6 @@ gcloud run deploy service-name \
    --no-allow-unauthenticated \
    --update-env-vars=CONFIG_PATH=config-path,PROJECT_ID=project-id
 ```
+## Slack BlockKit Template Functions
+- The `replace` function allows replacement of substrings in any {{template variables}} in the .json Slack template. (For example, the variable `.Build.FailureInfo.Detail` contains double quotes, which breaks the BlockKitTemplate parsing.)
+   - Usage: `{{replace .Build.FailureInfo.Detail "\"" "'"}}`

--- a/slack/main.go
+++ b/slack/main.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"text/template"
+	"strings"
 
 	"github.com/GoogleCloudPlatform/cloud-build-notifiers/lib/notifiers"
 	log "github.com/golang/glog"
@@ -64,7 +65,12 @@ func (s *slackNotifier) SetUp(ctx context.Context, cfg *notifiers.Config, blockK
 		return fmt.Errorf("failed to get token secret: %w", err)
 	}
 	s.webhookURL = wu
-	tmpl, err := template.New("blockkit_template").Parse(blockKitTemplate)
+	tmpl, err := template.New("blockkit_template").Funcs(template.FuncMap{
+		"replace": func(s, old, new string) string {
+			return strings.ReplaceAll(s, old, new)
+		},
+	}).Parse(blockKitTemplate)
+
 	s.tmpl = tmpl
 	s.br = br
 


### PR DESCRIPTION
Fixes #153 and #160 

This lets the user replace substrings in .json template variables. The most pressing need is to remove (or escape) double quotes, which breaks the template due to json not expecting unescaped double quotes. 

The Cloud Build .Build object has some properties which come with double quotes: `.Build.FailureInfo.Detail` is one such object: a typical FailureInfo object looks like:

```
failureInfo:
  detail: 'Build step failure: build step 7 "gcr.io/google-appengine/exec-wrapper"
    failed: step exited with non-zero status: 1'
  type: USER_BUILD_STEP
```

