### PR TITLE
Build binaries without dependency on cgo

### DIFF
--- a/bigquery/Dockerfile
+++ b/bigquery/Dockerfile
@@ -15,6 +15,7 @@
 FROM golang AS build-env
 COPY . /go-src/
 WORKDIR /go-src/bigquery
+ENV CGO_ENABLED=0
 RUN go test /go-src/bigquery
 RUN go build -o /go-app .
 

--- a/githubissues/Dockerfile
+++ b/githubissues/Dockerfile
@@ -15,6 +15,7 @@
 FROM golang AS build-env
 COPY . /go-src/
 WORKDIR /go-src/githubissues
+ENV CGO_ENABLED=0
 RUN go test /go-src/githubissues
 RUN go build -o /go-app .
 

--- a/googlechat/Dockerfile
+++ b/googlechat/Dockerfile
@@ -15,6 +15,7 @@
 FROM golang AS build-env
 COPY . /go-src/
 WORKDIR /go-src/googlechat
+ENV CGO_ENABLED=0
 RUN go test /go-src/googlechat
 RUN go build -o /go-app .
 

--- a/http/Dockerfile
+++ b/http/Dockerfile
@@ -15,6 +15,7 @@
 FROM golang AS build-env
 COPY . /go-src/
 WORKDIR /go-src/http
+ENV CGO_ENABLED=0
 RUN go test /go-src/http
 RUN go build -o /go-app .
 

--- a/lib/notifiers/Dockerfile
+++ b/lib/notifiers/Dockerfile
@@ -15,5 +15,6 @@
 FROM golang AS build-env
 COPY . /go-src/
 WORKDIR /go-src/lib/notifiers
+ENV CGO_ENABLED=0
 RUN go test /go-src/lib/notifiers
 RUN go build -o /dev/null .

--- a/slack/Dockerfile
+++ b/slack/Dockerfile
@@ -15,6 +15,7 @@
 FROM golang AS build-env
 COPY . /go-src/
 WORKDIR /go-src/slack
+ENV CGO_ENABLED=0
 RUN go test /go-src/slack
 RUN go build -o /go-app .
 

--- a/smtp/Dockerfile
+++ b/smtp/Dockerfile
@@ -15,6 +15,7 @@
 FROM golang AS build-env
 COPY . /go-src/
 WORKDIR /go-src/smtp
+ENV CGO_ENABLED=0
 RUN go test /go-src/smtp
 RUN go build -o /go-app .
 


### PR DESCRIPTION
When trying to build new versions of the images, these fail due to missing dynamic libs in the container:

```
Step #1: /go-app: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /go-app)
Step #1: /go-app: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /go-app)
```

Adding CGO_ENABLED=0 makes the go compiler produce a binary that doesn't require those libs.