### PR TITLE
[SMTP] Customize Subject Email (by build template)

### DIFF
--- a/smtp/main.go
+++ b/smtp/main.go
@@ -66,7 +66,7 @@ func (s *smtpNotifier) SetUp(ctx context.Context, cfg *notifiers.Config, cfgTemp
 	}
 	s.htmlTmpl = htmlTmpl
 
-	if _, subjectFound := cfg.Spec.Notification.Delivery["Subject"]; subjectFound {
+	if _, subjectFound := cfg.Spec.Notification.Delivery["subject"]; subjectFound {
 		textTmpl, err := textTemplate.New("subject_template").Parse(cfg.Spec.Notification.Delivery["Subject"].(string))
 		if err != nil {
 			return fmt.Errorf("failed to parse TEXT subject template: %w", err)

--- a/smtp/main.go
+++ b/smtp/main.go
@@ -66,8 +66,8 @@ func (s *smtpNotifier) SetUp(ctx context.Context, cfg *notifiers.Config, cfgTemp
 	}
 	s.htmlTmpl = htmlTmpl
 
-	if _, subjectFound := cfg.Spec.Notification.Delivery["subject"]; subjectFound {
-		textTmpl, err := textTemplate.New("subject_template").Parse(cfg.Spec.Notification.Delivery["Subject"].(string))
+	if subject, subjectFound := cfg.Spec.Notification.Delivery["subject"]; subjectFound {
+		textTmpl, err := textTemplate.New("subject_template").Parse(subject.(string))
 		if err != nil {
 			return fmt.Errorf("failed to parse TEXT subject template: %w", err)
 		}

--- a/smtp/main.go
+++ b/smtp/main.go
@@ -18,7 +18,8 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"html/template"
+	htmlTemplate "html/template"
+	textTemplate "text/template"
 	"mime/quotedprintable"
 	"net/smtp"
 	"strings"
@@ -41,15 +42,16 @@ func main() {
 
 type smtpNotifier struct {
 	filter   notifiers.EventFilter
-	tmpl     *template.Template
+	htmlTmpl *htmlTemplate.Template
+	textTmpl *textTemplate.Template
 	mcfg     mailConfig
 	br       notifiers.BindingResolver
 	tmplView *notifiers.TemplateView
 }
 
 type mailConfig struct {
-	server, port, sender, from, password string
-	recipients                           []string
+	server, port, sender, from, password, subject string
+	recipients                                    []string
 }
 
 func (s *smtpNotifier) SetUp(ctx context.Context, cfg *notifiers.Config, cfgTemplate string, sg notifiers.SecretGetter, br notifiers.BindingResolver) error {
@@ -58,11 +60,19 @@ func (s *smtpNotifier) SetUp(ctx context.Context, cfg *notifiers.Config, cfgTemp
 		return fmt.Errorf("failed to create CELPredicate: %w", err)
 	}
 	s.filter = prd
-	tmpl, err := template.New("email_template").Parse(cfgTemplate)
+	htmlTmpl, err := htmlTemplate.New("email_template").Parse(cfgTemplate)
 	if err != nil {
 		return fmt.Errorf("failed to parse HTML email template: %w", err)
 	}
-	s.tmpl = tmpl
+	s.htmlTmpl = htmlTmpl
+
+	if _, subjectFound := cfg.Spec.Notification.Delivery["Subject"]; subjectFound {
+		textTmpl, err := textTemplate.New("subject_template").Parse(cfg.Spec.Notification.Delivery["Subject"].(string))
+		if err != nil {
+			return fmt.Errorf("failed to parse TEXT subject template: %w", err)
+		}
+		s.textTmpl = textTmpl
+	}
 
 	mcfg, err := getMailConfig(ctx, sg, cfg.Spec)
 	if err != nil {
@@ -175,11 +185,19 @@ func (s *smtpNotifier) buildEmail() (string, error) {
 	build.LogUrl = logURL
 
 	body := new(bytes.Buffer)
-	if err := s.tmpl.Execute(body, s.tmplView); err != nil {
+	if err := s.htmlTmpl.Execute(body, s.tmplView); err != nil {
 		return "", err
 	}
 
 	subject := fmt.Sprintf("Cloud Build [%s]: %s", build.ProjectId, build.Id)
+	if s.textTmpl != nil {
+		subjectTmpl := new(bytes.Buffer)
+		if err := s.textTmpl.Execute(subjectTmpl, s.tmplView); err != nil {
+			return "", err
+		}
+
+		subject = subjectTmpl.String()
+	}
 
 	header := make(map[string]string)
 	if s.mcfg.from != s.mcfg.sender {

--- a/smtp/main.go
+++ b/smtp/main.go
@@ -196,7 +196,8 @@ func (s *smtpNotifier) buildEmail() (string, error) {
 			return "", err
 		}
 
-		subject = subjectTmpl.String()
+		// Escape any string formatter
+		subject = strings.Join(strings.Fields(subjectTmpl.String()), " ")
 	}
 
 	header := make(map[string]string)

--- a/smtp/main_test.go
+++ b/smtp/main_test.go
@@ -47,16 +47,16 @@ const htmlBody = `<!doctype html>
 </div>
 <div class="card-content white">
 <table class="bordered">
-  <tbody>
+	<tbody>
 	<tr>
-	  <td>Status</td>
-	  <td>{{.Params.buildStatus}}</td>
+		<td>Status</td>
+		<td>{{.Params.buildStatus}}</td>
 	</tr>
 	<tr>
-	  <td>Log URL</td>
-	  <td><a href="{{.Build.LogUrl}}">Click Here</a></td>
+		<td>Log URL</td>
+		<td><a href="{{.Build.LogUrl}}">Click Here</a></td>
 	</tr>
-  </tbody>
+	</tbody>
 </table>
 </div>
 </div>
@@ -65,6 +65,8 @@ const htmlBody = `<!doctype html>
 </div>
 </div>
 </html>`
+
+const templateSubject = `Build {{.Build.Id}} Status: {{.Build.Status}}`
 
 type fakeSecretGetter struct{}
 
@@ -147,7 +149,7 @@ metadata:
   name: failed-build-email-notification
 spec:
   notification:
-    filter: event.buildTriggerStatus == “STATUS_FAILED”
+    filter: event.buildTriggerStatus == "STATUS_FAILED"
     delivery:
       server: smtp.example.com
       port: '587'
@@ -190,10 +192,6 @@ spec:
 }
 
 func TestDefaultEmailTemplate(t *testing.T) {
-	tmpl, err := template.New("email_template").Parse(htmlBody)
-	if err != nil {
-		t.Fatalf("template.Parse failed: %v", err)
-	}
 	build := &cbpb.Build{
 		Id:             "some-build-id",
 		ProjectId:      "my-project-id",
@@ -209,8 +207,30 @@ func TestDefaultEmailTemplate(t *testing.T) {
 		Params: map[string]string{"buildStatus": "SUCCESS"},
 	}
 
+	// Subject email template
+	subjectTmpl, err := template.New("subject_template").Parse(templateSubject)
+	if err != nil {
+			t.Fatalf("failed to parse subject template: %v", err)
+	}
+
+	subject := new(bytes.Buffer)
+	if err := subjectTmpl.Execute(subject, view); err != nil {
+			t.Fatalf("failed to execute subject template: %v", err)
+	}
+
+	expectedSubject := "Build some-build-id Status: SUCCESS"
+	if subject.String() != expectedSubject {
+			t.Errorf("expected subject %q, but got %q", expectedSubject, subject.String())
+	}
+
+	// Body email template
+	bodyTmpl, err := template.New("email_template").Parse(htmlBody)
+	if err != nil {
+		t.Fatalf("template.Parse failed: %v", err)
+	}
+
 	body := new(bytes.Buffer)
-	if err := tmpl.Execute(body, view); err != nil {
+	if err := bodyTmpl.Execute(body, view); err != nil {
 		t.Fatalf("failed to execute template: %v", err)
 	}
 

--- a/smtp/smtp.yaml.example
+++ b/smtp/smtp.yaml.example
@@ -48,6 +48,7 @@ spec:
     delivery:
       server: smtp.gmail.com
       port: '587'
+      subject: '{{ if eq .Build.Status 3 }}✅ Build Successful ({{ .Build.Substitutions.REPO_NAME }}){{ else }}❌ Build Failure ({{ .Build.Substitutions.REPO_NAME }}){{ end }} | {{.Build.Substitutions._COMMIT_MESSAGE}}'
       sender: example-sender@gmail.com
       from: example-from@gmail.com
       recipients:

--- a/smtp/smtp.yaml.example
+++ b/smtp/smtp.yaml.example
@@ -48,7 +48,7 @@ spec:
     delivery:
       server: smtp.gmail.com
       port: '587'
-      subject: '{{ if eq .Build.Status 3 }}✅ Build Successful ({{ .Build.Substitutions.REPO_NAME }}){{ else }}❌ Build Failure ({{ .Build.Substitutions.REPO_NAME }}){{ end }} | {{.Build.Substitutions._COMMIT_MESSAGE}}'
+      subject: '{{ if eq .Build.Status 3 }}✅ Build Successful ({{ .Build.Substitutions.REPO_NAME }}){{ else }}❌ Build Failure ({{ .Build.Substitutions.REPO_NAME }}){{ end }} | {{ if .Build.Substitutions._COMMIT_MESSAGE }} {{ if gt (len .Build.Substitutions._COMMIT_MESSAGE) 100 }}{{ slice .Build.Substitutions._COMMIT_MESSAGE 0 100 }}{{ else }}{{ .Build.Substitutions._COMMIT_MESSAGE }}{{ end }}{{ else }}{{ .Build.Substitutions.COMMIT_SHA }}{{ end }} [...]'
       sender: example-sender@gmail.com
       from: example-from@gmail.com
       recipients:


### PR DESCRIPTION
Example configuration:
```
spec:
  notification:
    delivery:
      subject: '{{ if eq .Build.Status 3 }}✅ Build Successful ({{ .Build.Substitutions.REPO_NAME }}){{ else }}❌ Build Failure ({{ .Build.Substitutions.REPO_NAME }}){{ end }} | {{.Build.Substitutions._COMMIT_MESSAGE}}'
```